### PR TITLE
Pallet data in pdf invoice

### DIFF
--- a/app/Actions/Accounting/Invoice/InvoiceRecurringBillTransactions.php
+++ b/app/Actions/Accounting/Invoice/InvoiceRecurringBillTransactions.php
@@ -25,7 +25,8 @@ class InvoiceRecurringBillTransactions extends OrgAction
                 'quantity'        => $transaction->quantity * $transaction->temporal_quantity,
                 'gross_amount'    => $transaction->gross_amount,
                 'net_amount'      => $transaction->net_amount,
-                'data'            => $transaction->data
+                'data'            => $transaction->data,
+                'recurring_bill_transaction_id' => $transaction->id
             ];
 
             StoreInvoiceTransaction::make()->action($invoice, $transaction->historicAsset, $data);

--- a/app/Actions/Accounting/Invoice/UI/ShowInvoice.php
+++ b/app/Actions/Accounting/Invoice/UI/ShowInvoice.php
@@ -237,9 +237,9 @@ class ShowInvoice extends OrgAction
                     'workshop_route' => $this->getOutboxRoute($invoice)
                 ],
 
-                InvoiceTabsEnum::ITEMS->value => $this->tab == InvoiceTabsEnum::ITEMS->value ?
-                    fn () => InvoiceTransactionsResource::collection(IndexInvoiceTransactions::run($invoice, InvoiceTabsEnum::ITEMS->value))
-                    : Inertia::lazy(fn () => InvoiceTransactionsResource::collection(IndexInvoiceTransactions::run($invoice, InvoiceTabsEnum::ITEMS->value))),
+                InvoiceTabsEnum::GROUPED->value => $this->tab == InvoiceTabsEnum::GROUPED->value ?
+                    fn () => InvoiceTransactionsResource::collection(IndexInvoiceTransactions::run($invoice, InvoiceTabsEnum::GROUPED->value))
+                    : Inertia::lazy(fn () => InvoiceTransactionsResource::collection(IndexInvoiceTransactions::run($invoice, InvoiceTabsEnum::GROUPED->value))),
 
                 InvoiceTabsEnum::EMAIL->value => $this->tab == InvoiceTabsEnum::EMAIL->value ?
                     fn () => DispatchedEmailResource::collection(IndexDispatchedEmails::run($invoice->customer, InvoiceTabsEnum::EMAIL->value))
@@ -254,7 +254,7 @@ class ShowInvoice extends OrgAction
             ]
         )->table(IndexPayments::make()->tableStructure($invoice, [], InvoiceTabsEnum::PAYMENTS->value))
             ->table(IndexDispatchedEmails::make()->tableStructure($invoice->customer, prefix: InvoiceTabsEnum::EMAIL->value))
-            ->table(IndexInvoiceTransactions::make()->tableStructure($invoice, InvoiceTabsEnum::ITEMS->value));
+            ->table(IndexInvoiceTransactions::make()->tableStructure($invoice, InvoiceTabsEnum::GROUPED->value));
     }
 
 

--- a/app/Actions/Accounting/Invoice/UI/ShowInvoice.php
+++ b/app/Actions/Accounting/Invoice/UI/ShowInvoice.php
@@ -9,6 +9,7 @@
 namespace App\Actions\Accounting\Invoice\UI;
 
 use App\Actions\Accounting\InvoiceTransaction\UI\IndexInvoiceTransactions;
+use App\Actions\Accounting\InvoiceTransaction\UI\IndexItemizedInvoiceTransactions;
 use App\Actions\Accounting\Payment\UI\IndexPayments;
 use App\Actions\Comms\DispatchedEmail\UI\IndexDispatchedEmails;
 use App\Actions\Fulfilment\Fulfilment\UI\ShowFulfilment;
@@ -20,6 +21,7 @@ use App\Enums\Comms\Outbox\OutboxCodeEnum;
 use App\Enums\UI\Accounting\InvoiceTabsEnum;
 use App\Http\Resources\Accounting\InvoiceResource;
 use App\Http\Resources\Accounting\InvoiceTransactionsResource;
+use App\Http\Resources\Accounting\ItemizedInvoiceTransactionsResource;
 use App\Http\Resources\Accounting\PaymentsResource;
 use App\Http\Resources\Mail\DispatchedEmailResource;
 use App\Models\Accounting\Invoice;
@@ -241,6 +243,10 @@ class ShowInvoice extends OrgAction
                     fn () => InvoiceTransactionsResource::collection(IndexInvoiceTransactions::run($invoice, InvoiceTabsEnum::GROUPED->value))
                     : Inertia::lazy(fn () => InvoiceTransactionsResource::collection(IndexInvoiceTransactions::run($invoice, InvoiceTabsEnum::GROUPED->value))),
 
+                InvoiceTabsEnum::ITEMIZED->value => $this->tab == InvoiceTabsEnum::ITEMIZED->value ?
+                    fn () => ItemizedInvoiceTransactionsResource::collection(IndexItemizedInvoiceTransactions::run($invoice, InvoiceTabsEnum::ITEMIZED->value))
+                    : Inertia::lazy(fn () => ItemizedInvoiceTransactionsResource::collection(IndexItemizedInvoiceTransactions::run($invoice, InvoiceTabsEnum::ITEMIZED->value))),
+
                 InvoiceTabsEnum::EMAIL->value => $this->tab == InvoiceTabsEnum::EMAIL->value ?
                     fn () => DispatchedEmailResource::collection(IndexDispatchedEmails::run($invoice->customer, InvoiceTabsEnum::EMAIL->value))
                     : Inertia::lazy(fn () => DispatchedEmailResource::collection(IndexDispatchedEmails::run($invoice->customer, InvoiceTabsEnum::EMAIL->value))),
@@ -254,7 +260,8 @@ class ShowInvoice extends OrgAction
             ]
         )->table(IndexPayments::make()->tableStructure($invoice, [], InvoiceTabsEnum::PAYMENTS->value))
             ->table(IndexDispatchedEmails::make()->tableStructure($invoice->customer, prefix: InvoiceTabsEnum::EMAIL->value))
-            ->table(IndexInvoiceTransactions::make()->tableStructure($invoice, InvoiceTabsEnum::GROUPED->value));
+            ->table(IndexInvoiceTransactions::make()->tableStructure($invoice, InvoiceTabsEnum::GROUPED->value))
+            ->table(IndexItemizedInvoiceTransactions::make()->tableStructure($invoice, InvoiceTabsEnum::ITEMIZED->value));
     }
 
 

--- a/app/Actions/Accounting/Invoice/UI/ShowInvoiceDeleted.php
+++ b/app/Actions/Accounting/Invoice/UI/ShowInvoiceDeleted.php
@@ -239,9 +239,9 @@ class ShowInvoiceDeleted extends OrgAction
                     'workshop_route' => $this->getOutboxRoute($invoice)
                 ],
 
-                InvoiceTabsEnum::ITEMS->value => $this->tab == InvoiceTabsEnum::ITEMS->value ?
-                    fn () => InvoiceTransactionsResource::collection(IndexInvoiceTransactions::run($invoice, InvoiceTabsEnum::ITEMS->value))
-                    : Inertia::lazy(fn () => InvoiceTransactionsResource::collection(IndexInvoiceTransactions::run($invoice, InvoiceTabsEnum::ITEMS->value))),
+                InvoiceTabsEnum::GROUPED->value => $this->tab == InvoiceTabsEnum::GROUPED->value ?
+                    fn () => InvoiceTransactionsResource::collection(IndexInvoiceTransactions::run($invoice, InvoiceTabsEnum::GROUPED->value))
+                    : Inertia::lazy(fn () => InvoiceTransactionsResource::collection(IndexInvoiceTransactions::run($invoice, InvoiceTabsEnum::GROUPED->value))),
 
                 InvoiceTabsEnum::PAYMENTS->value => $this->tab == InvoiceTabsEnum::PAYMENTS->value ?
                     fn () => PaymentsResource::collection(IndexPayments::run($invoice))
@@ -250,7 +250,7 @@ class ShowInvoiceDeleted extends OrgAction
 
             ]
         )->table(IndexPayments::make()->tableStructure($invoice, [], InvoiceTabsEnum::PAYMENTS->value))
-            ->table(IndexInvoiceTransactions::make()->tableStructure($invoice, InvoiceTabsEnum::ITEMS->value));
+            ->table(IndexInvoiceTransactions::make()->tableStructure($invoice, InvoiceTabsEnum::GROUPED->value));
     }
 
 

--- a/app/Actions/Accounting/Invoice/WithInvoicesExport.php
+++ b/app/Actions/Accounting/Invoice/WithInvoicesExport.php
@@ -30,6 +30,8 @@ trait WithInvoicesExport
                 if (!empty($transaction->data['pallet_id'])) {
                     $pallet = Pallet::find($transaction->data['pallet_id']);
                     $transaction->pallet = $pallet->reference;
+                } elseif ($transaction->model_type == 'Rental') {
+                    $transaction->pallet = $transaction->recurringBillTransaction->item->reference;
                 }
 
                 if (!empty($transaction->data['date'])) {

--- a/app/Actions/Accounting/Invoice/WithInvoicesExport.php
+++ b/app/Actions/Accounting/Invoice/WithInvoicesExport.php
@@ -30,8 +30,10 @@ trait WithInvoicesExport
                 if (!empty($transaction->data['pallet_id'])) {
                     $pallet = Pallet::find($transaction->data['pallet_id']);
                     $transaction->pallet = $pallet->reference;
+                    $transaction->customerPallet = $pallet->customer_reference;
                 } elseif ($transaction->model_type == 'Rental' && $transaction->recurringBillTransaction) {
                     $transaction->pallet = $transaction->recurringBillTransaction->item->reference;
+                    $transaction->customerPallet = $transaction->recurringBillTransaction->item->customer_reference;
                 }
 
                 if (!empty($transaction->data['date'])) {

--- a/app/Actions/Accounting/Invoice/WithInvoicesExport.php
+++ b/app/Actions/Accounting/Invoice/WithInvoicesExport.php
@@ -30,11 +30,8 @@ trait WithInvoicesExport
                 if (!empty($transaction->data['pallet_id'])) {
                     $pallet = Pallet::find($transaction->data['pallet_id']);
                     $transaction->pallet = $pallet->reference;
-                } elseif ($transaction->model_type == 'Rental') {
-                    if($transaction->recurringBillTransaction)
-                    {
-                        $transaction->pallet = $transaction->recurringBillTransaction->item->reference;
-                    }
+                } elseif ($transaction->model_type == 'Rental' && $transaction->recurringBillTransaction) {
+                    $transaction->pallet = $transaction->recurringBillTransaction->item->reference;
                 }
 
                 if (!empty($transaction->data['date'])) {

--- a/app/Actions/Accounting/Invoice/WithInvoicesExport.php
+++ b/app/Actions/Accounting/Invoice/WithInvoicesExport.php
@@ -31,7 +31,10 @@ trait WithInvoicesExport
                     $pallet = Pallet::find($transaction->data['pallet_id']);
                     $transaction->pallet = $pallet->reference;
                 } elseif ($transaction->model_type == 'Rental') {
-                    $transaction->pallet = $transaction->recurringBillTransaction->item->reference;
+                    if($transaction->recurringBillTransaction)
+                    {
+                        $transaction->pallet = $transaction->recurringBillTransaction->item->reference;
+                    }
                 }
 
                 if (!empty($transaction->data['date'])) {

--- a/app/Actions/Accounting/InvoiceTransaction/ExportFulfilmentInvoiceTransactions.php
+++ b/app/Actions/Accounting/InvoiceTransaction/ExportFulfilmentInvoiceTransactions.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * author Arya Permana - Kirin
+ * created on 21-03-2025-09h-20m
+ * github: https://github.com/KirinZero0
+ * copyright 2025
+*/
+
+namespace App\Actions\Accounting\InvoiceTransaction;
+
+use App\Actions\Traits\WithExportData;
+use App\Exports\Accounting\FulfilmentInvoiceTransactionsExport;
+use App\Exports\Accounting\InvoiceTransactionsExport;
+use App\Exports\Inventory\LocationsExport;
+use App\Models\Accounting\Invoice;
+use Lorisleiva\Actions\ActionRequest;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Lorisleiva\Actions\Concerns\WithAttributes;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+class ExportFulfilmentInvoiceTransactions
+{
+    use AsAction;
+    use WithAttributes;
+    use WithExportData;
+
+    /**
+     * @throws \Throwable
+     */
+    public function handle(Invoice $invoice, array $modelData): BinaryFileResponse
+    {
+        $type = $modelData['type'];
+
+        return $this->export(new FulfilmentInvoiceTransactionsExport($invoice), 'invoice_transactions', $type);
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function asController(Invoice $invoice, ActionRequest $request): BinaryFileResponse
+    {
+        $this->setRawAttributes($request->all());
+        $this->validateAttributes();
+
+        return $this->handle($invoice, $request->all());
+    }
+}

--- a/app/Actions/Accounting/InvoiceTransaction/StoreInvoiceTransaction.php
+++ b/app/Actions/Accounting/InvoiceTransaction/StoreInvoiceTransaction.php
@@ -31,11 +31,15 @@ class StoreInvoiceTransaction extends OrgAction
     {
         if (Arr::exists($modelData, 'pallet_id')) {
             $palletId = Arr::pull($modelData, 'pallet_id');
+        } else {
+            $palletId = Arr::pull($modelData, 'data.pallet_id');
         }
         if (Arr::exists($modelData, 'handle_date')) {
             $handlingDate = Arr::pull($modelData, 'handle_date');
+        } else {
+            $handlingDate = Arr::pull($modelData, 'data.date');
         }
-
+        
         data_set($modelData, 'date', now(), overwrite: false);
 
         if ($model instanceof Transaction) {
@@ -129,6 +133,7 @@ class StoreInvoiceTransaction extends OrgAction
             'pallet_id'       => ['sometimes'],
             'handle_date'     => ['sometimes'],
             'data'            => ['sometimes', 'array'],
+            'recurring_bill_transaction_id' => ['sometimes'],
         ];
 
         if (!$this->strict) {

--- a/app/Actions/Accounting/InvoiceTransaction/UI/IndexItemizedInvoiceTransactions.php
+++ b/app/Actions/Accounting/InvoiceTransaction/UI/IndexItemizedInvoiceTransactions.php
@@ -39,6 +39,7 @@ class IndexItemizedInvoiceTransactions extends OrgAction
             ->defaultSort('invoice_transactions.id')
             ->select([
                 'invoice_transactions.model_type',
+                'invoice_transactions.model_id',
                 'invoice_transactions.in_process',
                 'invoice_transactions.data',
                 'historic_assets.code',

--- a/app/Actions/Accounting/InvoiceTransaction/UI/IndexItemizedInvoiceTransactions.php
+++ b/app/Actions/Accounting/InvoiceTransaction/UI/IndexItemizedInvoiceTransactions.php
@@ -34,7 +34,8 @@ class IndexItemizedInvoiceTransactions extends OrgAction
         $queryBuilder->where('invoice_transactions.invoice_id', $invoice->id);
         $queryBuilder->leftJoin('historic_assets', 'invoice_transactions.historic_asset_id', 'historic_assets.id');
         $queryBuilder->leftJoin('assets', 'invoice_transactions.asset_id', 'assets.id');
-
+        $queryBuilder->leftJoin('invoices', 'invoice_transactions.invoice_id', 'invoices.id');
+        $queryBuilder->leftJoin('currencies', 'invoices.currency_id', 'currencies.id');
         $queryBuilder
             ->defaultSort('invoice_transactions.id')
             ->select([
@@ -50,6 +51,8 @@ class IndexItemizedInvoiceTransactions extends OrgAction
                 'invoice_transactions.quantity',
                 'invoice_transactions.net_amount',
                 'invoice_transactions.recurring_bill_transaction_id',
+                'currencies.code as currency_code',
+                'currencies.id as currency_id'
             ]);
 
 

--- a/app/Actions/Accounting/InvoiceTransaction/UI/IndexItemizedInvoiceTransactions.php
+++ b/app/Actions/Accounting/InvoiceTransaction/UI/IndexItemizedInvoiceTransactions.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ * author Arya Permana - Kirin
+ * created on 20-03-2025-15h-51m
+ * github: https://github.com/KirinZero0
+ * copyright 2025
+*/
+
+namespace App\Actions\Accounting\InvoiceTransaction\UI;
+
+
+use App\Actions\OrgAction;
+use App\Http\Resources\Fulfilment\RecurringBillTransactionsResource;
+use App\InertiaTable\InertiaTable;
+use App\Models\Fulfilment\RecurringBill;
+use App\Models\Fulfilment\RecurringBillTransaction;
+use App\Services\QueryBuilder;
+use Closure;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use App\Enums\Fulfilment\RecurringBill\RecurringBillStatusEnum;
+use App\Models\Accounting\Invoice;
+use App\Models\Accounting\InvoiceTransaction;
+
+class IndexItemizedInvoiceTransactions extends OrgAction
+{
+    public function handle(Invoice $invoice, $prefix = null): LengthAwarePaginator
+    {
+        if ($prefix) {
+            InertiaTable::updateQueryBuilderParameters($prefix);
+        }
+
+        $queryBuilder = QueryBuilder::for(InvoiceTransaction::class);
+        $queryBuilder->where('invoice_transactions.invoice_id', $invoice->id);
+        $queryBuilder->leftJoin('historic_assets', 'invoice_transactions.historic_asset_id', 'historic_assets.id');
+        $queryBuilder->leftJoin('assets', 'invoice_transactions.asset_id', 'assets.id');
+
+        $queryBuilder
+            ->defaultSort('invoice_transactions.id')
+            ->select([
+                'invoice_transactions.model_type',
+                'invoice_transactions.in_process',
+                'invoice_transactions.data',
+                'historic_assets.code',
+                'historic_assets.name',
+                'invoice_transactions.historic_asset_id',
+                'assets.id as asset_id',
+                'assets.shop_id as asset_shop_id',
+                'invoice_transactions.quantity',
+                'invoice_transactions.net_amount',
+                'invoice_transactions.recurring_bill_transaction_id',
+            ]);
+
+
+        return $queryBuilder->allowedSorts(['id', 'code'])
+            ->withPaginator($prefix, tableName: request()->route()->getName())
+            ->withQueryString();
+    }
+
+    public function tableStructure(Invoice $parent, $prefix = null): Closure
+    {
+        return function (InertiaTable $table) use ($prefix, $parent) {
+            if ($prefix) {
+                $table
+                    ->name($prefix)
+                    ->pageName($prefix.'Page');
+            }
+
+            $table
+                ->withModelOperations()
+                ->withGlobalSearch();
+
+                $table->column(key: 'type', label: __('type'), canBeHidden: false, sortable: true, searchable: true);
+
+                $table->column(key: 'description', label: __('description'), canBeHidden: false, sortable: true, searchable: true);
+                $table->column(key: 'code', label: __('code'), canBeHidden: false, sortable: true, searchable: true);
+                $table->column(key: 'quantity', label: __('quantity'), canBeHidden: false, sortable: true, searchable: true, type: 'number');
+                $table->column(key: 'net_amount', label: __('net'), canBeHidden: false, sortable: true, searchable: true, type: 'number');
+                $table->defaultSort('code');
+
+        };
+    }
+
+
+    public function jsonResponse(LengthAwarePaginator $recurringBillTransactions): AnonymousResourceCollection
+    {
+        return RecurringBillTransactionsResource::collection($recurringBillTransactions);
+    }
+}

--- a/app/Actions/Accounting/StandaloneFulfilmentInvoice/UI/ShowStandaloneFulfilmentInvoiceInProcess.php
+++ b/app/Actions/Accounting/StandaloneFulfilmentInvoice/UI/ShowStandaloneFulfilmentInvoiceInProcess.php
@@ -17,6 +17,7 @@ use App\Actions\Fulfilment\WithFulfilmentCustomerSubNavigation;
 use App\Actions\OrgAction;
 use App\Enums\Comms\Outbox\OutboxCodeEnum;
 use App\Enums\UI\Accounting\InvoiceTabsEnum;
+use App\Enums\UI\Accounting\StandaloneFulfilmentInvoiceTabsEnum;
 use App\Http\Resources\Accounting\InvoiceResource;
 use App\Http\Resources\Accounting\StandaloneFulfilmentInvoiceTransactionsResource;
 use App\Models\Accounting\Invoice;
@@ -43,7 +44,7 @@ class ShowStandaloneFulfilmentInvoiceInProcess extends OrgAction
     public function asController(Organisation $organisation, Fulfilment $fulfilment, FulfilmentCustomer $fulfilmentCustomer, Invoice $invoice, ActionRequest $request): Invoice
     {
         $this->parent = $fulfilmentCustomer;
-        $this->initialisationFromFulfilment($fulfilment, $request)->withTab(InvoiceTabsEnum::values());
+        $this->initialisationFromFulfilment($fulfilment, $request)->withTab(StandaloneFulfilmentInvoiceTabsEnum::values());
 
         return $this->handle($invoice);
     }
@@ -56,8 +57,7 @@ class ShowStandaloneFulfilmentInvoiceInProcess extends OrgAction
             $disable = false;
             $tooltip = 'complete invoice';
         }
-        $navigation = InvoiceTabsEnum::navigation();
-        unset($navigation[InvoiceTabsEnum::PAYMENTS->value]);
+        $navigation = StandaloneFulfilmentInvoiceTabsEnum::navigation();
 
         $subNavigation = $this->getFulfilmentCustomerSubNavigation($this->parent, $request);
 
@@ -222,12 +222,12 @@ class ShowStandaloneFulfilmentInvoiceInProcess extends OrgAction
                     'workshop_route' => $this->getOutboxRoute($invoice)
                 ],
 
-                InvoiceTabsEnum::GROUPED->value => $this->tab == InvoiceTabsEnum::GROUPED->value ?
-                    fn () => StandaloneFulfilmentInvoiceTransactionsResource::collection(IndexStandaloneFulfilmentInvoiceTransactions::run($invoice, InvoiceTabsEnum::GROUPED->value))
-                    : Inertia::lazy(fn () => StandaloneFulfilmentInvoiceTransactionsResource::collection(IndexStandaloneFulfilmentInvoiceTransactions::run($invoice, InvoiceTabsEnum::GROUPED->value))),
+                StandaloneFulfilmentInvoiceTabsEnum::ITEMS->value => $this->tab == StandaloneFulfilmentInvoiceTabsEnum::ITEMS->value ?
+                    fn () => StandaloneFulfilmentInvoiceTransactionsResource::collection(IndexStandaloneFulfilmentInvoiceTransactions::run($invoice, StandaloneFulfilmentInvoiceTabsEnum::ITEMS->value))
+                    : Inertia::lazy(fn () => StandaloneFulfilmentInvoiceTransactionsResource::collection(IndexStandaloneFulfilmentInvoiceTransactions::run($invoice, StandaloneFulfilmentInvoiceTabsEnum::ITEMS->value))),
             ]
         )->table(IndexPayments::make()->tableStructure($invoice, [], InvoiceTabsEnum::PAYMENTS->value))
-            ->table(IndexStandaloneFulfilmentInvoiceTransactions::make()->tableStructure(InvoiceTabsEnum::GROUPED->value));
+            ->table(IndexStandaloneFulfilmentInvoiceTransactions::make()->tableStructure(StandaloneFulfilmentInvoiceTabsEnum::ITEMS->value));
     }
 
     public function getBreadcrumbs(string $routeName, array $routeParameters, string $suffix = ''): array

--- a/app/Actions/Accounting/StandaloneFulfilmentInvoice/UI/ShowStandaloneFulfilmentInvoiceInProcess.php
+++ b/app/Actions/Accounting/StandaloneFulfilmentInvoice/UI/ShowStandaloneFulfilmentInvoiceInProcess.php
@@ -222,12 +222,12 @@ class ShowStandaloneFulfilmentInvoiceInProcess extends OrgAction
                     'workshop_route' => $this->getOutboxRoute($invoice)
                 ],
 
-                InvoiceTabsEnum::ITEMS->value => $this->tab == InvoiceTabsEnum::ITEMS->value ?
-                    fn () => StandaloneFulfilmentInvoiceTransactionsResource::collection(IndexStandaloneFulfilmentInvoiceTransactions::run($invoice, InvoiceTabsEnum::ITEMS->value))
-                    : Inertia::lazy(fn () => StandaloneFulfilmentInvoiceTransactionsResource::collection(IndexStandaloneFulfilmentInvoiceTransactions::run($invoice, InvoiceTabsEnum::ITEMS->value))),
+                InvoiceTabsEnum::GROUPED->value => $this->tab == InvoiceTabsEnum::GROUPED->value ?
+                    fn () => StandaloneFulfilmentInvoiceTransactionsResource::collection(IndexStandaloneFulfilmentInvoiceTransactions::run($invoice, InvoiceTabsEnum::GROUPED->value))
+                    : Inertia::lazy(fn () => StandaloneFulfilmentInvoiceTransactionsResource::collection(IndexStandaloneFulfilmentInvoiceTransactions::run($invoice, InvoiceTabsEnum::GROUPED->value))),
             ]
         )->table(IndexPayments::make()->tableStructure($invoice, [], InvoiceTabsEnum::PAYMENTS->value))
-            ->table(IndexStandaloneFulfilmentInvoiceTransactions::make()->tableStructure(InvoiceTabsEnum::ITEMS->value));
+            ->table(IndexStandaloneFulfilmentInvoiceTransactions::make()->tableStructure(InvoiceTabsEnum::GROUPED->value));
     }
 
     public function getBreadcrumbs(string $routeName, array $routeParameters, string $suffix = ''): array

--- a/app/Actions/Maintenance/Aurora/RepairFulfilmentInvoiceMissingPalletData.php
+++ b/app/Actions/Maintenance/Aurora/RepairFulfilmentInvoiceMissingPalletData.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Thu, 20 Mar 2025 17:26:20 Malaysia Time, Kuala Lumpur, Malaysia
+ * Copyright (c) 2025, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\Maintenance\Aurora;
+
+use App\Actions\Traits\WithOrganisationSource;
+use App\Enums\Catalogue\Shop\ShopTypeEnum;
+use App\Models\Accounting\Invoice;
+use App\Models\Accounting\InvoiceTransaction;
+use App\Models\Catalogue\Shop;
+use App\Models\Fulfilment\RecurringBillTransaction;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class RepairFulfilmentInvoiceMissingPalletData
+{
+    use AsAction;
+    use WithOrganisationSource;
+
+
+    public function handle(Command $command, Invoice $invoice): void
+    {
+        if ($invoice->shop->type !== ShopTypeEnum::FULFILMENT) {
+            return;
+        }
+
+        if (!$invoice->recurringBill) {
+            return;
+        }
+
+        $recurringBillTransactions     = $invoice->recurringBill->transactions()->where('item_type', 'Pallet')->get();
+        $freeRecurringBillTransactions = $this->getFreeRecurringBillTransactions($invoice, $recurringBillTransactions);
+
+        $invoiceTransactions     = $invoice->invoiceTransactions()->leftJoin('assets', 'invoice_transactions.asset_id', '=', 'assets.id')->where('assets.type', 'rental')->get();
+        $freeInvoiceTransactions = $this->getFreeTransactions($invoice);
+        $command->table(
+            ['Invoice ID', 'Recurring Bill ID', 'RB Transactions', 'Free RB Transactions', 'Invoice Transactions', 'Free Invoice Transactions'],
+            [
+                [
+                    $invoice->reference,
+                    $invoice->recurringBill->reference,
+                    $recurringBillTransactions->count(),
+                    $freeRecurringBillTransactions->count(),
+                    $invoiceTransactions->count(),
+                    $freeInvoiceTransactions->count()
+                ]
+            ]
+        );
+
+        foreach ($freeInvoiceTransactions as $invoiceTransaction) {
+            $recurringBillTransaction = $this->matchRecurringBillTransaction($invoiceTransaction);
+            if ($recurringBillTransaction) {
+                $invoiceTransaction->update(['recurring_bill_transaction_id' => $recurringBillTransaction->id]);
+                $command->info('Matched Invoice Transaction '.$invoiceTransaction->id.' to Recurring Bill Transaction '.$recurringBillTransaction->id);
+            }
+        }
+    }
+
+
+    public function matchRecurringBillTransaction(InvoiceTransaction $invoiceTransaction)
+    {
+        return RecurringBillTransaction::leftJoin('invoice_transactions', 'recurring_bill_transactions.id', '=', 'invoice_transactions.recurring_bill_transaction_id')
+            ->select('recurring_bill_transactions.*')
+            ->where('recurring_bill_id', $invoiceTransaction->invoice->recurring_bill_id)
+            ->where('item_type', 'Pallet')
+            ->where('recurring_bill_transactions.asset_id', $invoiceTransaction->asset_id)
+            ->where('recurring_bill_transactions.temporal_quantity', $invoiceTransaction->quantity)
+            ->whereNull('invoice_transactions.id')
+            ->orderBy('recurring_bill_transactions.created_at')
+            ->first();
+    }
+
+    public function getFreeTransactions($invoice): Collection
+    {
+        return InvoiceTransaction::leftJoin('assets', 'invoice_transactions.asset_id', '=', 'assets.id')
+            ->select('invoice_transactions.*')
+            ->where('invoice_id', $invoice->id)
+            ->where('assets.type', 'rental')
+            ->where('recurring_bill_transaction_id', null)
+            ->get();
+    }
+
+    public function getFreeRecurringBillTransactions($invoice, $recurringBillTransactions)
+    {
+        return $recurringBillTransactions->filter(function ($transaction) use ($invoice) {
+            return !InvoiceTransaction::withTrashed()
+                ->where('invoice_id', $invoice->id)
+                ->where('recurring_bill_transaction_id', $transaction->id)->exists();
+        });
+    }
+
+    public function getCommandSignature(): string
+    {
+        return 'maintenance:repair_fulfilment_invoice_missing_pallet {invoice_id?}';
+    }
+
+
+    public function asCommand(Command $command): int
+    {
+        if ($command->argument('invoice_id')) {
+            $invoice = Invoice::find($command->argument('invoice_id'));
+            $this->handle($command, $invoice);
+        } else {
+            $fulfilmentShops = Shop::where('type', ShopTypeEnum::FULFILMENT)->pluck('id')->toArray();
+
+            $invoices = Invoice::whereNull('source_id')->whereIn('shop_id', $fulfilmentShops)->get();
+
+            foreach ($invoices as $invoice) {
+                $this->handle($command, $invoice);
+            }
+        }
+
+
+        return 0;
+    }
+}

--- a/app/Actions/Retina/Accounting/Invoice/Transaction/ExportRetinaFulfilmentInvoiceTransactions.php
+++ b/app/Actions/Retina/Accounting/Invoice/Transaction/ExportRetinaFulfilmentInvoiceTransactions.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * author Arya Permana - Kirin
+ * created on 21-03-2025-09h-49m
+ * github: https://github.com/KirinZero0
+ * copyright 2025
+*/
+
+namespace App\Actions\Retina\Accounting\Invoice\Transaction;
+
+use App\Actions\Accounting\InvoiceTransaction\ExportFulfilmentInvoiceTransactions;
+use App\Actions\Accounting\InvoiceTransaction\ExportInvoiceTransactions;
+use App\Actions\Traits\WithExportData;
+use App\Exports\Accounting\InvoiceTransactionsExport;
+use App\Exports\Inventory\LocationsExport;
+use App\Models\Accounting\Invoice;
+use Lorisleiva\Actions\ActionRequest;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Lorisleiva\Actions\Concerns\WithAttributes;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+class ExportRetinaFulfilmentInvoiceTransactions
+{
+    use AsAction;
+    use WithAttributes;
+    use WithExportData;
+
+    /**
+     * @throws \Throwable
+     */
+    public function handle(Invoice $invoice, array $modelData): BinaryFileResponse
+    {
+        return ExportFulfilmentInvoiceTransactions::run($invoice, $modelData);
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function asController(Invoice $invoice, ActionRequest $request): BinaryFileResponse
+    {
+        $this->setRawAttributes($request->all());
+        $this->validateAttributes();
+
+        return $this->handle($invoice, $request->all());
+    }
+}

--- a/app/Actions/Retina/Billing/UI/ShowRetinaInvoice.php
+++ b/app/Actions/Retina/Billing/UI/ShowRetinaInvoice.php
@@ -151,9 +151,9 @@ class ShowRetinaInvoice extends RetinaAction
                 'invoice' => InvoiceResource::make($invoice),
 
 
-                InvoiceTabsEnum::ITEMS->value => $this->tab == InvoiceTabsEnum::ITEMS->value ?
-                    fn () => InvoiceTransactionsResource::collection(IndexRetinaInvoiceTransactions::run($invoice, InvoiceTabsEnum::ITEMS->value))
-                    : Inertia::lazy(fn () => InvoiceTransactionsResource::collection(IndexRetinaInvoiceTransactions::run($invoice, InvoiceTabsEnum::ITEMS->value))),
+                InvoiceTabsEnum::GROUPED->value => $this->tab == InvoiceTabsEnum::GROUPED->value ?
+                    fn () => InvoiceTransactionsResource::collection(IndexRetinaInvoiceTransactions::run($invoice, InvoiceTabsEnum::GROUPED->value))
+                    : Inertia::lazy(fn () => InvoiceTransactionsResource::collection(IndexRetinaInvoiceTransactions::run($invoice, InvoiceTabsEnum::GROUPED->value))),
 
                 InvoiceTabsEnum::PAYMENTS->value => $this->tab == InvoiceTabsEnum::PAYMENTS->value ?
                     fn () => PaymentsResource::collection(IndexRetinaPayments::run($invoice))
@@ -162,7 +162,7 @@ class ShowRetinaInvoice extends RetinaAction
 
             ]
         )->table(IndexRetinaPayments::make()->tableStructure($invoice, [], InvoiceTabsEnum::PAYMENTS->value))
-            ->table(IndexRetinaInvoiceTransactions::make()->tableStructure($invoice, InvoiceTabsEnum::ITEMS->value));
+            ->table(IndexRetinaInvoiceTransactions::make()->tableStructure($invoice, InvoiceTabsEnum::GROUPED->value));
     }
 
 

--- a/app/Actions/Retina/Billing/UI/ShowRetinaInvoice.php
+++ b/app/Actions/Retina/Billing/UI/ShowRetinaInvoice.php
@@ -122,6 +122,12 @@ class ShowRetinaInvoice extends RetinaAction
                         'invoice' => $invoice->slug
                     ]
                 ],
+                'exportTransactionsRoute' => [
+                    'name'       => 'retina.fulfilment.billing.invoices.invoice-transactions.export',
+                    'parameters' => [
+                        'invoice' => $invoice->slug
+                    ]
+                ],
                 'box_stats'      => [
                     'customer'    => [
                         'route'        => [

--- a/app/Actions/Retina/Billing/UI/ShowRetinaInvoice.php
+++ b/app/Actions/Retina/Billing/UI/ShowRetinaInvoice.php
@@ -8,12 +8,14 @@
 
 namespace App\Actions\Retina\Billing\UI;
 
+use App\Actions\Accounting\InvoiceTransaction\UI\IndexItemizedInvoiceTransactions;
 use App\Actions\Retina\Accounting\Invoice\Transaction\UI\IndexRetinaInvoiceTransactions;
 use App\Actions\Retina\Accounting\Payment\UI\IndexRetinaPayments;
 use App\Actions\RetinaAction;
 use App\Enums\UI\Accounting\InvoiceTabsEnum;
 use App\Http\Resources\Accounting\InvoiceResource;
 use App\Http\Resources\Accounting\InvoiceTransactionsResource;
+use App\Http\Resources\Accounting\ItemizedInvoiceTransactionsResource;
 use App\Http\Resources\Accounting\PaymentsResource;
 use App\Models\Accounting\Invoice;
 use Inertia\Inertia;
@@ -44,8 +46,6 @@ class ShowRetinaInvoice extends RetinaAction
     public function htmlResponse(Invoice $invoice, ActionRequest $request): Response
     {
         $toPayAmount   = round($invoice->total_amount - $invoice->payment_amount, 2);
-
-
 
         return Inertia::render(
             'Billing/RetinaInvoice',
@@ -155,6 +155,10 @@ class ShowRetinaInvoice extends RetinaAction
                     fn () => InvoiceTransactionsResource::collection(IndexRetinaInvoiceTransactions::run($invoice, InvoiceTabsEnum::GROUPED->value))
                     : Inertia::lazy(fn () => InvoiceTransactionsResource::collection(IndexRetinaInvoiceTransactions::run($invoice, InvoiceTabsEnum::GROUPED->value))),
 
+                InvoiceTabsEnum::ITEMIZED->value => $this->tab == InvoiceTabsEnum::ITEMIZED->value ?
+                    fn () => ItemizedInvoiceTransactionsResource::collection(IndexItemizedInvoiceTransactions::run($invoice, InvoiceTabsEnum::ITEMIZED->value))
+                    : Inertia::lazy(fn () => ItemizedInvoiceTransactionsResource::collection(IndexItemizedInvoiceTransactions::run($invoice, InvoiceTabsEnum::ITEMIZED->value))),
+
                 InvoiceTabsEnum::PAYMENTS->value => $this->tab == InvoiceTabsEnum::PAYMENTS->value ?
                     fn () => PaymentsResource::collection(IndexRetinaPayments::run($invoice))
                     : Inertia::lazy(fn () => PaymentsResource::collection(IndexRetinaPayments::run($invoice))),
@@ -162,6 +166,7 @@ class ShowRetinaInvoice extends RetinaAction
 
             ]
         )->table(IndexRetinaPayments::make()->tableStructure($invoice, [], InvoiceTabsEnum::PAYMENTS->value))
+            ->table(IndexItemizedInvoiceTransactions::make()->tableStructure($invoice, InvoiceTabsEnum::ITEMIZED->value))
             ->table(IndexRetinaInvoiceTransactions::make()->tableStructure($invoice, InvoiceTabsEnum::GROUPED->value));
     }
 

--- a/app/Enums/UI/Accounting/InvoiceTabsEnum.php
+++ b/app/Enums/UI/Accounting/InvoiceTabsEnum.php
@@ -17,6 +17,7 @@ enum InvoiceTabsEnum: string
     use HasTabs;
 
     case GROUPED                  = 'grouped';
+    case ITEMIZED               = 'itemized';
     case HISTORY                = 'history';
     case PAYMENTS               = 'payments';
     case EMAIL = 'email';
@@ -48,6 +49,10 @@ enum InvoiceTabsEnum: string
 
             InvoiceTabsEnum::GROUPED => [
                 'title' => __('Grouped'),
+                'icon'  => 'fal fa-bars',
+            ],
+            InvoiceTabsEnum::ITEMIZED => [
+                'title' => __('Itemized'),
                 'icon'  => 'fal fa-bars',
             ],
         };

--- a/app/Enums/UI/Accounting/InvoiceTabsEnum.php
+++ b/app/Enums/UI/Accounting/InvoiceTabsEnum.php
@@ -48,11 +48,11 @@ enum InvoiceTabsEnum: string
             ],
 
             InvoiceTabsEnum::GROUPED => [
-                'title' => __('Grouped'),
+                'title' => __('Itemized by rental/service'),
                 'icon'  => 'fal fa-bars',
             ],
             InvoiceTabsEnum::ITEMIZED => [
-                'title' => __('Itemized'),
+                'title' => __('Itemised by pallets'),
                 'icon'  => 'fal fa-bars',
             ],
         };

--- a/app/Enums/UI/Accounting/InvoiceTabsEnum.php
+++ b/app/Enums/UI/Accounting/InvoiceTabsEnum.php
@@ -16,7 +16,7 @@ enum InvoiceTabsEnum: string
     use EnumHelperTrait;
     use HasTabs;
 
-    case ITEMS                  = 'items';
+    case GROUPED                  = 'grouped';
     case HISTORY                = 'history';
     case PAYMENTS               = 'payments';
     case EMAIL = 'email';
@@ -46,8 +46,8 @@ enum InvoiceTabsEnum: string
                 'align' => 'right',
             ],
 
-            InvoiceTabsEnum::ITEMS => [
-                'title' => __('Items'),
+            InvoiceTabsEnum::GROUPED => [
+                'title' => __('Grouped'),
                 'icon'  => 'fal fa-bars',
             ],
         };

--- a/app/Enums/UI/Accounting/StandaloneFulfilmentInvoiceTabsEnum.php
+++ b/app/Enums/UI/Accounting/StandaloneFulfilmentInvoiceTabsEnum.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * author Arya Permana - Kirin
+ * created on 21-03-2025-09h-09m
+ * github: https://github.com/KirinZero0
+ * copyright 2025
+*/
+
+namespace App\Enums\UI\Accounting;
+
+use App\Enums\EnumHelperTrait;
+use App\Enums\HasTabs;
+
+enum StandaloneFulfilmentInvoiceTabsEnum: string
+{
+    use EnumHelperTrait;
+    use HasTabs;
+
+    case ITEMS                  = 'items';
+    case HISTORY                = 'history';
+    case EMAIL = 'email';
+
+    public function blueprint(): array
+    {
+        return match ($this) {
+            StandaloneFulfilmentInvoiceTabsEnum::EMAIL => [
+                'align' => 'right',
+                'title' => __('email'),
+                'icon'  => 'fal fa-envelope',
+                'type'  => 'icon'
+            ],
+
+            StandaloneFulfilmentInvoiceTabsEnum::HISTORY     => [
+                'title' => __('History'),
+                'icon'  => 'fal fa-clock',
+                'type'  => 'icon',
+                'align' => 'right',
+            ],
+
+            StandaloneFulfilmentInvoiceTabsEnum::ITEMS => [
+                'title' => __('Items'),
+                'icon'  => 'fal fa-bars',
+            ],
+        };
+    }
+}

--- a/app/Exports/Accounting/FulfilmentInvoiceTransactionsExport.php
+++ b/app/Exports/Accounting/FulfilmentInvoiceTransactionsExport.php
@@ -44,11 +44,13 @@ class FulfilmentInvoiceTransactionsExport implements FromQuery, WithMapping, Sho
             $service = Service::find($row->model_id);
             if ($service->is_pallet_handling == true) {
                 $pallet = Pallet::find($row->data['pallet_id']);
-                $palletData = $pallet->customer_reference . ' (' . $pallet->reference . ')';
+                $palletData = $pallet->reference;
+                $palletRef = $pallet->customer_reference;
             }
         } 
         elseif (isset($row->recurringBillTransaction)) {
-            $palletData = $row->recurringBillTransaction->item->customer_reference . ' (' . $row->recurringBillTransaction->item->reference . ')';
+            $palletData = $row->recurringBillTransaction->item->reference;
+            $palletRef = $row->recurringBillTransaction->item->customer_reference;
         }
 
         return [
@@ -57,6 +59,7 @@ class FulfilmentInvoiceTransactionsExport implements FromQuery, WithMapping, Sho
             $row->historicAsset->code,
             $row->historicAsset->name,
             $palletData,
+            $palletRef,
             $row->quantity,
             $row->invoice->currency->symbol . $row->net_amount,
         ];
@@ -69,7 +72,8 @@ class FulfilmentInvoiceTransactionsExport implements FromQuery, WithMapping, Sho
             'Type',
             'Code',
             'Name',
-            'Pallet',
+            'Pallet ID',
+            'Pallet Reference',
             'Quantity',
             'Net',
         ];

--- a/app/Exports/Accounting/FulfilmentInvoiceTransactionsExport.php
+++ b/app/Exports/Accounting/FulfilmentInvoiceTransactionsExport.php
@@ -44,13 +44,13 @@ class FulfilmentInvoiceTransactionsExport implements FromQuery, WithMapping, Sho
             $service = Service::find($row->model_id);
             if ($service->is_pallet_handling == true) {
                 $pallet = Pallet::find($row->data['pallet_id']);
-                $palletData = $pallet->customer_reference . ' - ' . $pallet->reference;
+                $palletData = $pallet->customer_reference . ' (' . $pallet->reference . ')';
             }
         } 
-
-        if (isset($row->recurringBillTransaction)) {
-            $palletData = $row->recurringBillTransaction->item->customer_reference . ' - ' . $row->recurringBillTransaction->item->reference;
+        elseif (isset($row->recurringBillTransaction)) {
+            $palletData = $row->recurringBillTransaction->item->customer_reference . ' (' . $row->recurringBillTransaction->item->reference . ')';
         }
+
         return [
             $row->id,
             $row->model_type,
@@ -58,7 +58,7 @@ class FulfilmentInvoiceTransactionsExport implements FromQuery, WithMapping, Sho
             $row->historicAsset->name,
             $palletData,
             $row->quantity,
-            $row->net_amount,
+            $row->invoice->currency->symbol . $row->net_amount,
         ];
     }
 

--- a/app/Exports/Accounting/FulfilmentInvoiceTransactionsExport.php
+++ b/app/Exports/Accounting/FulfilmentInvoiceTransactionsExport.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * author Arya Permana - Kirin
+ * created on 21-03-2025-09h-30m
+ * github: https://github.com/KirinZero0
+ * copyright 2025
+*/
+
+namespace App\Exports\Accounting;
+
+use App\Models\Accounting\Invoice;
+use App\Models\Accounting\InvoiceTransaction;
+use App\Models\Billables\Service;
+use App\Models\Fulfilment\Pallet;
+use App\Models\Inventory\Location;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder;
+use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithMapping;
+
+class FulfilmentInvoiceTransactionsExport implements FromQuery, WithMapping, ShouldAutoSize, WithHeadings
+{
+    protected $invoice;
+
+    public function __construct(Invoice $invoice)
+    {
+        $this->invoice = $invoice;
+    }
+
+
+    public function query(): Relation|\Illuminate\Database\Eloquent\Builder|InvoiceTransaction|Builder
+    {
+        return InvoiceTransaction::query()->where('invoice_id', $this->invoice->id);
+    }
+
+    /** @var Location $row */
+    public function map($row): array
+    {
+        $palletData = 'no data';
+
+        if($row->model_type == 'Service') {
+            $service = Service::find($row->model_id);
+            if ($service->is_pallet_handling == true) {
+                $pallet = Pallet::find($row->data['pallet_id']);
+                $palletData = $pallet->customer_reference . ' - ' . $pallet->reference;
+            }
+        } 
+
+        if (isset($row->recurringBillTransaction)) {
+            $palletData = $row->recurringBillTransaction->item->customer_reference . ' - ' . $row->recurringBillTransaction->item->reference;
+        }
+        return [
+            $row->id,
+            $row->model_type,
+            $row->historicAsset->code,
+            $row->historicAsset->name,
+            $palletData,
+            $row->quantity,
+            $row->net_amount,
+        ];
+    }
+
+    public function headings(): array
+    {
+        return [
+            '#',
+            'Type',
+            'Code',
+            'Name',
+            'Pallet',
+            'Quantity',
+            'Net',
+        ];
+    }
+}

--- a/app/Http/Resources/Accounting/ItemizedInvoiceTransactionsResource.php
+++ b/app/Http/Resources/Accounting/ItemizedInvoiceTransactionsResource.php
@@ -125,6 +125,7 @@ class ItemizedInvoiceTransactionsResource extends JsonResource
         return [
             'type'                      => $this->model_type,
             'code'                      => $this->code,
+            'name'                      => $this->name,
             'description'       => [
                         'model' => $desc_model,
                         'title' => $desc_title,
@@ -135,6 +136,7 @@ class ItemizedInvoiceTransactionsResource extends JsonResource
             'net_amount'                => $this->net_amount,
             'currency_code'             => $this->currency_code,
             'in_process'                => $this->in_process,
+            'currency_code'             => $this->currency_code,
         ];
     }
 }

--- a/app/Http/Resources/Accounting/ItemizedInvoiceTransactionsResource.php
+++ b/app/Http/Resources/Accounting/ItemizedInvoiceTransactionsResource.php
@@ -1,0 +1,72 @@
+<?php
+/*
+ * author Arya Permana - Kirin
+ * created on 20-03-2025-16h-01m
+ * github: https://github.com/KirinZero0
+ * copyright 2025
+*/
+
+namespace App\Http\Resources\Accounting;
+
+use App\Models\Accounting\Invoice;
+use App\Models\Catalogue\Asset;
+use App\Models\Catalogue\Shop;
+use App\Models\Fulfilment\Pallet;
+use Carbon\Carbon;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property string $code
+ * @property string $quantity
+ * @property string $net_amount
+ * @property string $name
+ * @property string $currency_code
+ * @property mixed $id
+ * @property mixed $in_process
+ */
+class ItemizedInvoiceTransactionsResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+
+
+        $palletRef = null;
+        $handlingDate = null;
+        $palletRoute = null;
+
+        if ($this->model_type == 'Service') {
+            if (!empty($this->data['pallet_id'])) {
+                $pallet = Pallet::find($this->data['pallet_id']);
+                $palletRef = $pallet->reference;
+                $palletRoute = [
+                    'name' => 'grp.org.fulfilments.show.crm.customers.show.pallets.show',
+                    'parameters'    => [
+                        'organisation'          => $pallet->organisation->slug,
+                        'fulfilment'            => $pallet->fulfilment->slug,
+                        'fulfilmentCustomer'    => $pallet->fulfilmentCustomer->slug,
+                        'pallet'                 => $pallet->slug
+                    ]
+                ];
+            }
+
+            if (!empty($this->data['date'])) {
+                $handlingDate = Carbon::parse($this->data['date'])->format('d M Y');
+            }
+        } elseif ($this->model_type == 'Rental') {
+            
+        }
+
+        return [
+            'type'                      => $this->model_type,
+            'code'                      => $this->code,
+            'description'               => $this->name,
+            'quantity'                  => (int) $this->quantity,
+            'net_amount'                => $this->net_amount,
+            'currency_code'             => $this->currency_code,
+            'in_process'                => $this->in_process,
+            'pallet'                    => $palletRef,
+            'handling_date'             => $handlingDate,
+            'palletRoute'               => $palletRoute,
+        ];
+    }
+}

--- a/app/Http/Resources/Accounting/ItemizedInvoiceTransactionsResource.php
+++ b/app/Http/Resources/Accounting/ItemizedInvoiceTransactionsResource.php
@@ -47,30 +47,46 @@ class ItemizedInvoiceTransactionsResource extends JsonResource
                     $desc_title = $pallet->customer_reference;
                     $desc_model = __('Storage');
                     $desc_after_title = $pallet->reference;
-                    $desc_route = [
+                    $desc_route = match (request()->routeIs('retina.*')) {
+                    true => [
+                        'name'       => 'retina.fulfilment.storage.pallets.show',
+                        'parameters' => [
+                            'pallet'             => $pallet->slug
+                            ]
+                    ],  
+                    default => [
                         'name'       => 'grp.org.fulfilments.show.crm.customers.show.pallets.show',
                         'parameters' => [
                             'organisation'       => $request->route()->originalParameters()['organisation'],
                             'fulfilment'         => $request->route()->originalParameters()['fulfilment'],
                             'fulfilmentCustomer' => $pallet->fulfilmentCustomer->slug,
                             'pallet'             => $pallet->slug
+                            ]
                         ]
-                    ];
+                    };
                 }
             } elseif ($recurringBillTransaction->pallet_delivery_id) {
                 $palletDelivery = PalletDelivery::find($recurringBillTransaction->pallet_delivery_id);
                 if ($palletDelivery) {
                     $desc_title = $palletDelivery->reference;
                     $desc_model = __('Pallet Delivery');
-                    $desc_route = [
+                    $desc_route = match (request()->routeIs('retina.*')) {
+                    true => [
+                        'name' => 'retina.fulfilment.storage.pallet_deliveries.show',
+                        'parameters'    => [
+                            'palletDelivery'       => $palletDelivery->slug
+                            ]
+                    ],  
+                    default => [
                         'name' => 'grp.org.fulfilments.show.crm.customers.show.pallet_deliveries.show',
                         'parameters'    => [
                             'organisation'         => $request->route()->originalParameters()['organisation'],
                             'fulfilment'           => $request->route()->originalParameters()['fulfilment'],
                             'fulfilmentCustomer'   => $palletDelivery->fulfilmentCustomer->slug,
                             'palletDelivery'       => $palletDelivery->slug
+                            ]
                         ]
-                    ];
+                    };
                 }
     
             } elseif ($recurringBillTransaction->pallet_return_id) {
@@ -78,30 +94,41 @@ class ItemizedInvoiceTransactionsResource extends JsonResource
                 if ($palletReturn) {
                     $desc_title = $palletReturn->reference;
                     $desc_model = __('Pallet Return');
-                    $desc_route = [
+                    $desc_route = match (request()->routeIs('retina.*')) { 
+                    true => [
+                        'name' => 'retina.fulfilment.storage.pallet_returns.show',
+                        'parameters'    => [
+                            'palletReturn'       => $palletReturn->slug
+                            ]
+                    ],
+                    default => [
                         'name' => 'grp.org.fulfilments.show.crm.customers.show.pallet_returns.show',
                         'parameters'    => [
                             'organisation'         => $request->route()->originalParameters()['organisation'],
                             'fulfilment'           => $request->route()->originalParameters()['fulfilment'],
                             'fulfilmentCustomer'   => $palletReturn->fulfilmentCustomer->slug,
                             'palletReturn'       => $palletReturn->slug
+                            ]
                         ]
-                    ];
+                    };
                 }
             } elseif ($this->model_type === 'Space') {
                 $space = Space::find($this->model_id);
                 if ($space) {
                     $desc_model = __('Space (parking)');
                     $desc_title = $space->reference;
-                    $desc_route = [
+                    $desc_route = match (request()->routeIs('retina.*')) {
+                    true => [],
+                    default => [
                         'name' => 'grp.org.fulfilments.show.crm.customers.show.spaces.show',
                         'parameters'    => [
                             'organisation'          => $request->route()->originalParameters()['organisation'],
                             'fulfilment'            => $request->route()->originalParameters()['fulfilment'],
                             'fulfilmentCustomer'    => $space->fulfilmentCustomer->slug,
                             'space'                 => $space->slug
+                            ]
                         ]
-                    ];
+                    };
                 }
             }
         } 
@@ -112,15 +139,23 @@ class ItemizedInvoiceTransactionsResource extends JsonResource
                 $desc_title = $pallet->customer_reference;
                 $desc_after_title = $pallet->reference . ' - ' . Carbon::parse($this->data['date'])->format('d M Y');
                 $desc_model = __('Pallet Handling');
-                $desc_route = [
+                $desc_route = match (request()->routeIs('retina.*')) {
+                true => [
+                    'name'       => 'retina.fulfilment.storage.pallets.show',
+                    'parameters' => [
+                        'pallet'             => $pallet->slug
+                        ]
+                ], 
+                default =>[
                     'name'       => 'grp.org.fulfilments.show.crm.customers.show.pallets.show',
                     'parameters' => [
                         'organisation'       => $request->route()->originalParameters()['organisation'],
                         'fulfilment'         => $request->route()->originalParameters()['fulfilment'],
                         'fulfilmentCustomer' => $pallet->fulfilmentCustomer->slug,
                         'pallet'             => $pallet->slug
+                        ]
                     ]
-                ];
+                };
             }
         }
         return [

--- a/app/Http/Resources/Accounting/ItemizedInvoiceTransactionsResource.php
+++ b/app/Http/Resources/Accounting/ItemizedInvoiceTransactionsResource.php
@@ -44,8 +44,9 @@ class ItemizedInvoiceTransactionsResource extends JsonResource
             if ($this->model_type == 'Rental') {
                 $pallet = Pallet::find($recurringBillTransaction->item_id);
                 if ($pallet) {
-                    $desc_title = $pallet->reference;
+                    $desc_title = $pallet->customer_reference;
                     $desc_model = __('Storage');
+                    $desc_after_title = $pallet->reference;
                     $desc_route = [
                         'name'       => 'grp.org.fulfilments.show.crm.customers.show.pallets.show',
                         'parameters' => [
@@ -108,8 +109,8 @@ class ItemizedInvoiceTransactionsResource extends JsonResource
             $service = Service::find($this->model_id);
             if ($service->is_pallet_handling == true) {
                 $pallet = Pallet::find($this->data['pallet_id']);
-                $desc_title = $pallet->reference;
-                $desc_after_title = Carbon::parse($this->data['date'])->format('d M Y');
+                $desc_title = $pallet->customer_reference;
+                $desc_after_title = $pallet->reference . ' - ' . Carbon::parse($this->data['date'])->format('d M Y');
                 $desc_model = __('Pallet Handling');
                 $desc_route = [
                     'name'       => 'grp.org.fulfilments.show.crm.customers.show.pallets.show',

--- a/app/Http/Resources/Accounting/StandaloneFulfilmentInvoiceTransactionsResource.php
+++ b/app/Http/Resources/Accounting/StandaloneFulfilmentInvoiceTransactionsResource.php
@@ -28,8 +28,10 @@ class StandaloneFulfilmentInvoiceTransactionsResource extends JsonResource
 {
     public function toArray($request): array
     {
-
+        $palletRef = null;
+        $palletRoute = null;
         $editType = null;
+        $handlingDate = null;
         if ($this->model_type == 'Service') {
             $service = Service::find($this->model_id);
             $editType = $service->edit_type ?? null;

--- a/app/Models/Accounting/InvoiceTransaction.php
+++ b/app/Models/Accounting/InvoiceTransaction.php
@@ -13,6 +13,7 @@ use App\Models\Catalogue\HistoricAsset;
 use App\Models\Discounts\Offer;
 use App\Models\Discounts\OfferCampaign;
 use App\Models\Discounts\OfferComponent;
+use App\Models\Fulfilment\RecurringBillTransaction;
 use App\Models\Helpers\Currency;
 use App\Models\Helpers\InvoiceTransactionHasFeedback;
 use App\Models\Ordering\Order;
@@ -127,6 +128,11 @@ class InvoiceTransaction extends Model
     public function transaction(): BelongsTo
     {
         return $this->belongsTo(Transaction::class);
+    }
+
+    public function recurringBillTransaction(): BelongsTo
+    {
+        return $this->belongsTo(RecurringBillTransaction::class);
     }
 
     public function order(): BelongsTo

--- a/resources/js/Components/Tables/Grp/Org/Accounting/TableItemizedTransactions.vue
+++ b/resources/js/Components/Tables/Grp/Org/Accounting/TableItemizedTransactions.vue
@@ -1,0 +1,205 @@
+<script setup lang="ts">
+import Table from "@/Components/Table/Table.vue"
+import { inject, ref } from "vue"
+import { aikuLocaleStructure } from "@/Composables/useLocaleStructure"
+import { Link, router } from "@inertiajs/vue3"
+import { layoutStructure } from "@/Composables/useLayoutStructure"
+import { routeType } from "@/types/route"
+import Tag from "@/Components/Tag.vue"
+import Button from '@/Components/Elements/Buttons/Button.vue'
+import NumberWithButtonSave from "@/Components/NumberWithButtonSave.vue"
+import { trans } from "laravel-vue-i18n"
+
+defineProps<{
+	data: object
+	tab: string
+	status?: string
+}>()
+
+const locale = inject("locale", aikuLocaleStructure)
+const layout = inject("layout", layoutStructure)
+
+const getRoute = (item: {}) => {
+	const routeUpdate = <routeType>{}
+
+	if (item?.fulfilment_transaction_id) {
+		if (layout.app.name === "Aiku") {
+			routeUpdate.name = "grp.models.fulfilment-transaction.update"
+			routeUpdate.parameters = { fulfilmentTransaction: item?.fulfilment_transaction_id }
+		} else {
+			routeUpdate.name = "retina.models.fulfilment-transaction.update"
+			routeUpdate.parameters = { fulfilmentTransaction: item?.fulfilment_transaction_id }
+		}
+	} else {
+		routeUpdate.name = "grp.models.recurring_bill_transaction.update"
+		routeUpdate.parameters = { recurringBillTransaction: item?.id }
+	}
+
+	routeUpdate.method = "patch"
+
+	return routeUpdate
+}
+
+const onUpdateQuantity = (id: Number, fulfilment_transaction_id: number, value: number) => {
+	/* console.log(idFulfilmentTransaction, 'loasding', value); */
+
+	const routeUpdate = <routeType>{}
+	if (fulfilment_transaction_id) {
+		if (layout.app.name === "Aiku") {
+			routeUpdate.name = "grp.models.fulfilment-transaction.update"
+			routeUpdate.parameters = { fulfilmentTransaction: fulfilment_transaction_id }
+		} else {
+			routeUpdate.name = "retina.models.fulfilment-transaction.update"
+			routeUpdate.parameters = { fulfilmentTransaction: fulfilment_transaction_id }
+		}
+	} else {
+		routeUpdate.name = "grp.models.recurring_bill_transaction.update"
+		routeUpdate.parameters = { recurringBillTransaction: id }
+	}
+	value.patch(route(routeUpdate.name, routeUpdate.parameters), {
+		preserveScroll: true,
+	})
+}
+
+const isLoading = ref<string | boolean>(false)
+const onDeleteTransaction = (id: Number, fulfilment_transaction_id: number) => {
+	const routeDelete = <routeType>{}
+	if (fulfilment_transaction_id) {
+		if (layout.app.name === "Aiku") {
+			routeDelete.name = "grp.models.fulfilment-transaction.delete"
+			routeDelete.parameters = { fulfilmentTransaction: fulfilment_transaction_id }
+		} else {
+			routeDelete.name = "retina.models.fulfilment-transaction.delete"
+			routeDelete.parameters = { fulfilmentTransaction: fulfilment_transaction_id }
+		}
+	} else {
+		routeDelete.name = "grp.models.recurring_bill_transaction.delete"
+		routeDelete.parameters = { recurringBillTransaction: id }
+	}
+
+	router.delete(route(routeDelete.name, routeDelete.parameters), {
+		preserveScroll: true,
+		onStart: () => (isLoading.value = "buttonReset" + id),
+		onFinish: () => (isLoading.value = false),
+	})
+}
+</script>
+
+<template>
+	<div class="h-min">
+		<Table :resource="data" :name="tab" class="mt-5" :is-check-box="false">
+			<template #cell(description)="{ item }">
+				<div
+					v-if="
+						item.description?.model ||
+						item.description?.title ||
+						item.description?.after_title
+					">
+					<span v-if="item.description?.model">{{ item.description.model }}:</span>
+					<Link
+						v-if="item.description?.title && item.description.route?.name"
+						:href="
+							route(item.description.route?.name, item.description.route?.parameters)
+						"
+						class="primaryLink">
+						{{ item.description.title }}
+					</Link>
+					<span v-else>&nbsp;{{ item.description.title }}</span>
+
+					<div v-if="item.description.after_title" class="text-gray-400 italic text-xs">
+						({{ item.description.after_title }})
+					</div>
+				</div>
+
+				<div v-else></div>
+			</template>
+
+			<!-- Column: asset code -->
+			<template #cell(asset_code)="{ item }">
+				<div>
+					{{ item.asset_code }} <br />
+					<span class="text-gray-400">({{ item.asset_name }})</span>
+				</div>
+			</template>
+
+			<!-- Column: quantity -->
+			<template #cell(quantity)="{ item }">
+				<div class="flex justify-end">
+					<div
+						v-if="
+							item.edit_type !== 'net' &&
+							status == 'current' &&
+							item.data.type !== 'Pallet' &&
+							item.data.type !== 'Space'
+						">
+						<NumberWithButtonSave
+							v-model="item.quantity"
+							@onSave="
+								(e) => onUpdateQuantity(item.id, item.fulfilment_transaction_id, e)
+							" />
+					</div>
+					<div v-else-if="item.data.type == 'Pallet'">
+						{{ locale.number(item.quantity) }}
+						{{ item.quantity > 1 ? trans("days") : trans("day") }}
+					</div>
+					<div v-else-if="item.data.type == 'Product'">
+						{{ locale.number(item.quantity) }}
+						{{ item.quantity > 1 ? trans("pcs") : trans("pc") }}
+					</div>
+					<div v-else class="text-gray-500"></div>
+				</div>
+			</template>
+
+			<!-- Column: asset price -->
+			<template #cell(asset_price)="{ item }">
+				{{ locale.currencyFormat(item.currency_code, item.asset_price || 0) }}/{{
+					item.unit_label
+				}}
+				<Tag v-if="item['discount'] > 0" :theme="17" noHoverColor>
+					<template #label>
+						<font-awesome-icon icon="fal fa-tag" class="text-xs text-emerald-700" />
+						{{ item["discount"] }}%
+					</template>
+				</Tag>
+			</template>
+
+			<template #cell(total)="{ item, proxyItem }">
+				<div class="relative">
+					<template v-if="item.edit_type === 'net'">
+						<div class="w-72 float-right">
+							<NumberWithButtonSave
+								v-model="proxyItem.total"
+								:saveOnForm="true"
+								:routeSubmit="getRoute(item)"
+								keySubmit="net_amount"
+								:bindToTarget="{
+									mode: 'currency',
+									fluid: true,
+									currency: item.currency_code,
+									locale: 'en-US',
+									step: 0.25,
+								}" />
+						</div>
+					</template>
+
+					<Transition v-else name="spin-to-right">
+						<span :key="item.total">
+							{{ locale.currencyFormat(item.currency_code, item.total || 0) }}
+						</span>
+					</Transition>
+				</div>
+			</template>
+
+			<!-- Column: Action -->
+			<template #cell(actions)="{ item }">
+				<Button
+					v-if="item.data.type !== 'Pallet' && item.data.type !== 'Space'"
+					@click="() => onDeleteTransaction(item.id, item.fulfilment_transaction_id)"
+					:loading="isLoading === 'buttonReset' + item.id"
+					icon="fal fa-trash-alt"
+					type="negative"
+					v-tooltip="'Unselect this field'" />
+			</template>
+		</Table>
+	</div>
+</template>

--- a/resources/js/Components/Tables/Grp/Org/Accounting/TableItemizedTransactions.vue
+++ b/resources/js/Components/Tables/Grp/Org/Accounting/TableItemizedTransactions.vue
@@ -9,6 +9,7 @@ import Tag from "@/Components/Tag.vue"
 import Button from '@/Components/Elements/Buttons/Button.vue'
 import NumberWithButtonSave from "@/Components/NumberWithButtonSave.vue"
 import { trans } from "laravel-vue-i18n"
+import { useLocaleStore } from "@/Stores/locale"
 
 defineProps<{
 	data: object
@@ -86,6 +87,7 @@ const onDeleteTransaction = (id: Number, fulfilment_transaction_id: number) => {
 </script>
 
 <template>
+    <pre>{{ data }}</pre>
 	<div class="h-min">
 		<Table :resource="data" :name="tab" class="mt-5" :is-check-box="false">
 			<template #cell(description)="{ item }">
@@ -114,92 +116,9 @@ const onDeleteTransaction = (id: Number, fulfilment_transaction_id: number) => {
 				<div v-else></div>
 			</template>
 
-			<!-- Column: asset code -->
-			<template #cell(asset_code)="{ item }">
-				<div>
-					{{ item.asset_code }} <br />
-					<span class="text-gray-400">({{ item.asset_name }})</span>
-				</div>
-			</template>
-
-			<!-- Column: quantity -->
-			<template #cell(quantity)="{ item }">
-				<div class="flex justify-end">
-					<div
-						v-if="
-							item.edit_type !== 'net' &&
-							status == 'current' &&
-							item.data.type !== 'Pallet' &&
-							item.data.type !== 'Space'
-						">
-						<NumberWithButtonSave
-							v-model="item.quantity"
-							@onSave="
-								(e) => onUpdateQuantity(item.id, item.fulfilment_transaction_id, e)
-							" />
-					</div>
-					<div v-else-if="item.data.type == 'Pallet'">
-						{{ locale.number(item.quantity) }}
-						{{ item.quantity > 1 ? trans("days") : trans("day") }}
-					</div>
-					<div v-else-if="item.data.type == 'Product'">
-						{{ locale.number(item.quantity) }}
-						{{ item.quantity > 1 ? trans("pcs") : trans("pc") }}
-					</div>
-					<div v-else class="text-gray-500"></div>
-				</div>
-			</template>
-
-			<!-- Column: asset price -->
-			<template #cell(asset_price)="{ item }">
-				{{ locale.currencyFormat(item.currency_code, item.asset_price || 0) }}/{{
-					item.unit_label
-				}}
-				<Tag v-if="item['discount'] > 0" :theme="17" noHoverColor>
-					<template #label>
-						<font-awesome-icon icon="fal fa-tag" class="text-xs text-emerald-700" />
-						{{ item["discount"] }}%
-					</template>
-				</Tag>
-			</template>
-
-			<template #cell(total)="{ item, proxyItem }">
-				<div class="relative">
-					<template v-if="item.edit_type === 'net'">
-						<div class="w-72 float-right">
-							<NumberWithButtonSave
-								v-model="proxyItem.total"
-								:saveOnForm="true"
-								:routeSubmit="getRoute(item)"
-								keySubmit="net_amount"
-								:bindToTarget="{
-									mode: 'currency',
-									fluid: true,
-									currency: item.currency_code,
-									locale: 'en-US',
-									step: 0.25,
-								}" />
-						</div>
-					</template>
-
-					<Transition v-else name="spin-to-right">
-						<span :key="item.total">
-							{{ locale.currencyFormat(item.currency_code, item.total || 0) }}
-						</span>
-					</Transition>
-				</div>
-			</template>
-
-			<!-- Column: Action -->
-			<template #cell(actions)="{ item }">
-				<Button
-					v-if="item.data.type !== 'Pallet' && item.data.type !== 'Space'"
-					@click="() => onDeleteTransaction(item.id, item.fulfilment_transaction_id)"
-					:loading="isLoading === 'buttonReset' + item.id"
-					icon="fal fa-trash-alt"
-					type="negative"
-					v-tooltip="'Unselect this field'" />
-			</template>
+            <template #cell(net_amount)="{ item }">
+                <div class="text-gray-500">{{ useLocaleStore().currencyFormat( item.currency_code, item.net_amount)  }}</div>
+            </template>
 		</Table>
 	</div>
 </template>

--- a/resources/js/Components/Tables/Grp/Org/Accounting/TableItemizedTransactions.vue
+++ b/resources/js/Components/Tables/Grp/Org/Accounting/TableItemizedTransactions.vue
@@ -6,7 +6,7 @@ import { Link, router } from "@inertiajs/vue3"
 import { layoutStructure } from "@/Composables/useLayoutStructure"
 import { routeType } from "@/types/route"
 import Tag from "@/Components/Tag.vue"
-import Button from '@/Components/Elements/Buttons/Button.vue'
+import Button from "@/Components/Elements/Buttons/Button.vue"
 import NumberWithButtonSave from "@/Components/NumberWithButtonSave.vue"
 import { trans } from "laravel-vue-i18n"
 import { useLocaleStore } from "@/Stores/locale"
@@ -87,7 +87,6 @@ const onDeleteTransaction = (id: Number, fulfilment_transaction_id: number) => {
 </script>
 
 <template>
-    <pre>{{ data }}</pre>
 	<div class="h-min">
 		<Table :resource="data" :name="tab" class="mt-5" :is-check-box="false">
 			<template #cell(description)="{ item }">
@@ -113,12 +112,22 @@ const onDeleteTransaction = (id: Number, fulfilment_transaction_id: number) => {
 					</div>
 				</div>
 
-				<div v-else></div>
+				<div v-else>
+					<span class="text-gray-400 italic text-xs">data unavailable</span>
+                </div>
 			</template>
 
-            <template #cell(net_amount)="{ item }">
-                <div class="text-gray-500">{{ useLocaleStore().currencyFormat( item.currency_code, item.net_amount)  }}</div>
-            </template>
+			<template #cell(code)="{ item }">
+				<div>
+					{{ item.code }} <br />
+					<span class="text-gray-400">({{ item.name }})</span>
+				</div>
+			</template>
+			<template #cell(net_amount)="{ item }">
+				<div class="text-gray-500">
+					{{ useLocaleStore().currencyFormat(item.currency_code, item.net_amount) }}
+				</div>
+			</template>
 		</Table>
 	</div>
 </template>

--- a/resources/js/Pages/Grp/Org/Accounting/Invoice.vue
+++ b/resources/js/Pages/Grp/Org/Accounting/Invoice.vue
@@ -59,6 +59,7 @@ import NeedToPay from '@/Components/Utils/NeedToPay.vue'
 import EmptyState from '@/Components/Utils/EmptyState.vue'
 import TableDispatchedEmails from '@/Components/Tables/TableDispatchedEmails.vue'
 import InputNumber from 'primevue/inputnumber'
+import TableItemizedTransactions from '@/Components/Tables/Grp/Org/Accounting/TableItemizedTransactions.vue'
 // const locale = useLocaleStore()
 const locale = inject('locale', aikuLocaleStructure)
 
@@ -117,7 +118,7 @@ const handleTabUpdate = (tabSlug: string) => useTabChange(tabSlug, currentTab)
 const component = computed(() => {
     const components: Component = {
         grouped: TableInvoiceTransactions,
-        itemized: TableInvoiceTransactions,
+        itemized: TableItemizedTransactions,
         payments: TablePayments,
         details: ModelDetails,
         history: ModelChangelog,

--- a/resources/js/Pages/Grp/Org/Accounting/Invoice.vue
+++ b/resources/js/Pages/Grp/Org/Accounting/Invoice.vue
@@ -99,6 +99,7 @@ const props = defineProps<{
     recurring_bill_route: routeType
     invoice: InvoiceResource
     grouped: {}
+    itemized: {}
     payments: {}
     email?:{}
     details: {}
@@ -116,6 +117,7 @@ const handleTabUpdate = (tabSlug: string) => useTabChange(tabSlug, currentTab)
 const component = computed(() => {
     const components: Component = {
         grouped: TableInvoiceTransactions,
+        itemized: TableInvoiceTransactions,
         payments: TablePayments,
         details: ModelDetails,
         history: ModelChangelog,

--- a/resources/js/Pages/Grp/Org/Accounting/Invoice.vue
+++ b/resources/js/Pages/Grp/Org/Accounting/Invoice.vue
@@ -98,7 +98,7 @@ const props = defineProps<{
     order_summary: FieldOrderSummary[][]
     recurring_bill_route: routeType
     invoice: InvoiceResource
-    items: {}
+    grouped: {}
     payments: {}
     email?:{}
     details: {}
@@ -115,7 +115,7 @@ const handleTabUpdate = (tabSlug: string) => useTabChange(tabSlug, currentTab)
 
 const component = computed(() => {
     const components: Component = {
-        items: TableInvoiceTransactions,
+        grouped: TableInvoiceTransactions,
         payments: TablePayments,
         details: ModelDetails,
         history: ModelChangelog,

--- a/resources/js/Pages/Grp/Org/Accounting/InvoiceManual.vue
+++ b/resources/js/Pages/Grp/Org/Accounting/InvoiceManual.vue
@@ -102,7 +102,7 @@ const props = defineProps<{
     order_summary: FieldOrderSummary[][]
     recurring_bill_route: routeType
     invoice: InvoiceResource
-    items: {}
+    grouped: {}
     payments: {}
     details: {}
     history: {}
@@ -126,7 +126,7 @@ const handleTabUpdate = (tabSlug: string) => useTabChange(tabSlug, currentTab)
 
 const component = computed(() => {
     const components: Component = {
-        items: InvoiceManualTransactions,
+        grouped: InvoiceManualTransactions,
         // items: TableInvoiceTransactions,
         payments: TablePayments,
         details: ModelDetails,

--- a/resources/js/Pages/Grp/Org/Accounting/InvoiceManual.vue
+++ b/resources/js/Pages/Grp/Org/Accounting/InvoiceManual.vue
@@ -102,7 +102,7 @@ const props = defineProps<{
     order_summary: FieldOrderSummary[][]
     recurring_bill_route: routeType
     invoice: InvoiceResource
-    grouped: {}
+    items: {}
     payments: {}
     details: {}
     history: {}
@@ -126,7 +126,7 @@ const handleTabUpdate = (tabSlug: string) => useTabChange(tabSlug, currentTab)
 
 const component = computed(() => {
     const components: Component = {
-        grouped: InvoiceManualTransactions,
+        items: InvoiceManualTransactions,
         // items: TableInvoiceTransactions,
         payments: TablePayments,
         details: ModelDetails,

--- a/resources/js/Pages/Retina/Billing/RetinaInvoice.vue
+++ b/resources/js/Pages/Retina/Billing/RetinaInvoice.vue
@@ -36,6 +36,7 @@
 
   import NeedToPay from '@/Components/Utils/NeedToPay.vue'
 import TableHistories from '@/Components/Tables/Grp/Helpers/TableHistories.vue'
+import RetinaTableItemizedTransactions from './RetinaTableItemizedTransactions.vue'
   const locale = inject('locale', aikuLocaleStructure)
   
   
@@ -88,6 +89,7 @@ import TableHistories from '@/Components/Tables/Grp/Helpers/TableHistories.vue'
   const component = computed(() => {
       const components: Component = {
           grouped: TableInvoiceTransactions,
+          itemized: RetinaTableItemizedTransactions,
           payments: TablePayments,
           details: ModelDetails,
           history: TableHistories,

--- a/resources/js/Pages/Retina/Billing/RetinaInvoice.vue
+++ b/resources/js/Pages/Retina/Billing/RetinaInvoice.vue
@@ -1,10 +1,10 @@
   <script setup lang="ts">
-  import { Head } from '@inertiajs/vue3'
+  import { Head, usePage } from '@inertiajs/vue3'
   
   import PageHeading from '@/Components/Headings/PageHeading.vue'
   import { Link } from '@inertiajs/vue3'
   
-  import { computed, inject, ref, watch } from "vue"
+  import { computed, inject, ref, watch, watchEffect } from "vue"
   import type { Component } from "vue"
   import { useTabChange } from "@/Composables/tab-change"
   import ModelDetails from "@/Components/ModelDetails.vue"
@@ -100,7 +100,14 @@ import RetinaTableItemizedTransactions from './RetinaTableItemizedTransactions.v
       return components[currentTab.value]
   })
   
-  
+  const urlPage = ref(location)
+const cleanedSearchUrl = ref(location.search ? location.search.slice(1) : '')
+
+watchEffect(() => {
+    urlPage.value = location
+    cleanedSearchUrl.value = location.search ? location.search.slice(1) : ''
+    usePage().url  // to trigger watchEffect on filter table changed
+})
 
   
 
@@ -117,7 +124,12 @@ import RetinaTableItemizedTransactions from './RetinaTableItemizedTransactions.v
                   class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none text-base" v-tooltip="trans('Download in')">
                   <Button label="PDF" icon="fas fa-file-pdf" type="tertiary" />
               </a>
-              <a v-if="exportTransactionsRoute?.name" :href="route(exportTransactionsRoute.name, exportTransactionsRoute.parameters)" target="_blank"
+              <a v-if="exportTransactionsRoute?.name" :href="
+              exportTransactionsRoute
+                        ? `${route(exportTransactionsRoute.name, exportTransactionsRoute.parameters)}?type=xlsx`
+                        : `${urlPage.origin}${urlPage.pathname}/export?type=xlsx&${cleanedSearchUrl}`
+                "
+                 target="_blank"
                   class="mt-4  sm:mt-0 sm:flex-none text-base" v-tooltip="trans('Download in')">
                   <Button label="Excel" icon="fas fa-file-excel" type="tertiary" />
               </a>

--- a/resources/js/Pages/Retina/Billing/RetinaInvoice.vue
+++ b/resources/js/Pages/Retina/Billing/RetinaInvoice.vue
@@ -76,6 +76,7 @@ import RetinaTableItemizedTransactions from './RetinaTableItemizedTransactions.v
       recurring_bill_route: routeType
       invoice: InvoiceResource
       grouped: {}
+      itemized: {}
       payments: {}
       details: {}
       history: {}

--- a/resources/js/Pages/Retina/Billing/RetinaInvoice.vue
+++ b/resources/js/Pages/Retina/Billing/RetinaInvoice.vue
@@ -22,9 +22,9 @@
   import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
   import { library } from '@fortawesome/fontawesome-svg-core'
   import { faIdCardAlt, faMapMarkedAlt, faPhone, faChartLine, faCreditCard, faCube, faFolder, faPercent, faCalendarAlt, faDollarSign, faMapMarkerAlt, faPencil, faBuilding, faMoneyBillAlt } from '@fal'
-  import { faClock, faFileInvoice, faFilePdf } from '@fas'
+  import { faClock, faFileExcel, faFileInvoice, faFilePdf } from '@fas'
   import { faCheck } from '@far'
-  library.add(faCheck, faIdCardAlt, faMapMarkedAlt, faPhone, faFolder, faCube, faChartLine, faCreditCard, faClock, faFileInvoice, faPercent, faCalendarAlt, faBuilding, faDollarSign, faFilePdf, faMapMarkerAlt, faPencil, faMoneyBillAlt)
+  library.add(faCheck, faIdCardAlt, faMapMarkedAlt, faPhone, faFolder, faCube, faChartLine, faCreditCard, faClock, faFileInvoice, faPercent, faCalendarAlt, faBuilding, faDollarSign, faFilePdf, faMapMarkerAlt, faPencil, faMoneyBillAlt, faFileExcel)
   
 
   
@@ -72,6 +72,7 @@ import RetinaTableItemizedTransactions from './RetinaTableItemizedTransactions.v
           }
       }
       exportPdfRoute: routeType
+      exportTransactionsRoute: routeType
       order_summary: FieldOrderSummary[][]
       recurring_bill_route: routeType
       invoice: InvoiceResource
@@ -115,6 +116,10 @@ import RetinaTableItemizedTransactions from './RetinaTableItemizedTransactions.v
               <a v-if="exportPdfRoute?.name" :href="route(exportPdfRoute.name, exportPdfRoute.parameters)" target="_blank"
                   class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none text-base" v-tooltip="trans('Download in')">
                   <Button label="PDF" icon="fas fa-file-pdf" type="tertiary" />
+              </a>
+              <a v-if="exportTransactionsRoute?.name" :href="route(exportTransactionsRoute.name, exportTransactionsRoute.parameters)" target="_blank"
+                  class="mt-4  sm:mt-0 sm:flex-none text-base" v-tooltip="trans('Download in')">
+                  <Button label="Excel" icon="fas fa-file-excel" type="tertiary" />
               </a>
           </template>
       </PageHeading>

--- a/resources/js/Pages/Retina/Billing/RetinaInvoice.vue
+++ b/resources/js/Pages/Retina/Billing/RetinaInvoice.vue
@@ -74,7 +74,7 @@ import TableHistories from '@/Components/Tables/Grp/Helpers/TableHistories.vue'
       order_summary: FieldOrderSummary[][]
       recurring_bill_route: routeType
       invoice: InvoiceResource
-      items: {}
+      grouped: {}
       payments: {}
       details: {}
       history: {}
@@ -87,7 +87,7 @@ import TableHistories from '@/Components/Tables/Grp/Helpers/TableHistories.vue'
   
   const component = computed(() => {
       const components: Component = {
-          items: TableInvoiceTransactions,
+          grouped: TableInvoiceTransactions,
           payments: TablePayments,
           details: ModelDetails,
           history: TableHistories,

--- a/resources/js/Pages/Retina/Billing/RetinaTableItemizedTransactions.vue
+++ b/resources/js/Pages/Retina/Billing/RetinaTableItemizedTransactions.vue
@@ -10,7 +10,6 @@ defineProps<{
 	status?: string
 }>()
 
-
 </script>
 
 <template>
@@ -41,7 +40,7 @@ defineProps<{
 
 				<div v-else>
 					<span class="text-gray-400 italic text-xs">data unavailable</span>
-                </div>
+				</div>
 			</template>
 
 			<template #cell(code)="{ item }">

--- a/resources/views/invoices/templates/pdf/invoice.blade.php
+++ b/resources/views/invoices/templates/pdf/invoice.blade.php
@@ -245,11 +245,11 @@
             <td style="text-align:left" colspan="2">
                 @if($transaction->historicAsset)
                     {{ $transaction->historicAsset?->name }}
-                    @if(isset($transaction->data['pallet_id']))
+                    @if(isset($transaction->pallet))
                     <br>
                         {{ __('Pallet') }}: {{ $transaction->pallet }}
                     @endif
-                    @if(isset($transaction->data['date']))
+                    @if(isset($transaction->handling_date))
                     <br>
                         {{ __('Date') }}: {{ $transaction->handling_date }}
                     @endif

--- a/resources/views/invoices/templates/pdf/invoice.blade.php
+++ b/resources/views/invoices/templates/pdf/invoice.blade.php
@@ -247,7 +247,7 @@
                     {{ $transaction->historicAsset?->name }}
                     @if(isset($transaction->pallet))
                     <br>
-                        {{ __('Pallet') }}: {{ $transaction->pallet }}
+                        {{ __('Pallet') }}: {{$transaction->customerPallet}} ({{ $transaction->pallet }})
                     @endif
                     @if(isset($transaction->handling_date))
                     <br>

--- a/routes/retina/web/fulfilment/billing.php
+++ b/routes/retina/web/fulfilment/billing.php
@@ -7,6 +7,7 @@
  */
 
 use App\Actions\Retina\Accounting\Invoice\PdfRetinaInvoice;
+use App\Actions\Retina\Accounting\Invoice\Transaction\ExportRetinaFulfilmentInvoiceTransactions;
 use App\Actions\Retina\Billing\UI\IndexRetinaInvoices;
 use App\Actions\Retina\Billing\UI\ShowRetinaBillingDashboard;
 use App\Actions\Retina\Billing\UI\ShowRetinaInvoice;
@@ -21,4 +22,6 @@ Route::prefix('invoices')->as('invoices.')->group(function () {
     Route::get('/', IndexRetinaInvoices::class)->name('index');
     Route::get('{invoice}', ShowRetinaInvoice::class)->name('show');
     Route::get('/{invoice}/export', PdfRetinaInvoice::class)->name('download');
+    Route::get('/{invoice}/invoice-transactions/export', ExportRetinaFulfilmentInvoiceTransactions::class)->name('invoice-transactions.export');
+
 });


### PR DESCRIPTION
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 
 **PR Summary by Typo**
------------

**Overview**
This PR adds pallet data to PDF invoices, including pallet ID and customer reference. It introduces new actions and resources for itemized invoice transactions, improves data handling for `pallet_id` and `handle_date`, and includes a command to repair missing pallet data in fulfillment invoices.  Additionally, it adds an Excel export option for invoice transactions in the Retina billing section.

**Key Changes**
- Added `pallet` and `customerPallet` fields to invoice transactions for PDF display.
- Introduced `IndexItemizedInvoiceTransactions`, `ExportFulfilmentInvoiceTransactions`, and related UI components for itemized transaction handling.
- Updated `StoreInvoiceTransaction` to handle `pallet_id` and `handle_date` from nested data structures.
- Created `RepairFulfilmentInvoiceMissingPalletData` command to fix missing pallet data.
- Added Excel export functionality for fulfillment invoice transactions in Retina.
- Updated InvoiceTabsEnum to include GROUPED and ITEMIZED options.
- Created StandaloneFulfilmentInvoiceTabsEnum.

**Recommendations**
Not deployment ready. While the changes address the core issue and introduce valuable features, thorough testing is crucial before deploying to production.  Add integration tests to verify the accuracy of pallet data display on PDF invoices, the new itemized transaction features, and the data repair command.  Additionally, review the error handling and logging within the new actions and resources to ensure robustness in a production environment.  Consider adding more specific unit tests for complex logic, such as the matching algorithm in `RepairFulfilmentInvoiceMissingPalletData`.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>