### PR TITLE
Notification when create pallet return and pallet delivery

### DIFF
--- a/app/Actions/Comms/Email/SendNewCustomerNotification.php
+++ b/app/Actions/Comms/Email/SendNewCustomerNotification.php
@@ -82,6 +82,7 @@ class SendNewCustomerNotification extends OrgAction
             );
         }
 
+
     }
 
 

--- a/app/Actions/Comms/Email/SendPalletDeliveryProcessedNotification.php
+++ b/app/Actions/Comms/Email/SendPalletDeliveryProcessedNotification.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Author: Ganes <gustiganes@gmail.com>
+ * Created on: 21-03-2025, Bali, Indonesia
+ * Github: https://github.com/Ganes556
+ * Copyright: 2025
+ *
+*/
+
+namespace App\Actions\Comms\Email;
+
+use App\Actions\Comms\DispatchedEmail\StoreDispatchedEmail;
+use App\Actions\Comms\Traits\WithSendBulkEmails;
+use App\Actions\OrgAction;
+use App\Actions\Traits\Rules\WithNoStrictRules;
+use App\Actions\Traits\WithActionUpdate;
+use App\Enums\Comms\DispatchedEmail\DispatchedEmailProviderEnum;
+use App\Enums\Comms\Outbox\OutboxBuilderEnum;
+use App\Enums\Comms\Outbox\OutboxCodeEnum;
+use App\Enums\Comms\Outbox\OutboxTypeEnum;
+use App\Models\Comms\DispatchedEmail;
+use App\Models\Comms\Email;
+use App\Models\CRM\Customer;
+use Illuminate\Support\Arr;
+
+class SendPalletDeliveryProcessedNotification extends OrgAction
+{
+    use WithActionUpdate;
+    use WithNoStrictRules;
+    use WithSendBulkEmails;
+
+    private Email $email;
+
+    public function handle(Customer $customer): DispatchedEmail
+    {
+
+        $outbox = $customer->shop->outboxes()->where('code', OutboxCodeEnum::PALLET_DELIVERY_PROCESSED->value)->first();
+        $outboxDispatch = $customer->shop->outboxes()->where('type', OutboxTypeEnum::CUSTOMER_NOTIFICATION)->first();
+
+        $recipient       = $customer;
+        $dispatchedEmail = StoreDispatchedEmail::run($outbox->emailOngoingRun, $recipient, [
+            'is_test'       => false,
+            'outbox_id'     => $outboxDispatch->id,
+            'email_address' => $recipient->email,
+            'provider'      => DispatchedEmailProviderEnum::SES
+        ]);
+        $dispatchedEmail->refresh();
+
+        if ($outbox->builder == OutboxBuilderEnum::BLADE) {
+            $emailHtmlBody = Arr::get($outbox->emailOngoingRun?->email?->liveSnapshot?->layout, 'blade_template');
+        } else {
+            $emailHtmlBody = $outbox->emailOngoingRun?->email?->liveSnapshot?->compiled_layout;
+        }
+
+        return $this->sendEmailWithMergeTags(
+            $dispatchedEmail,
+            $outbox->emailOngoingRun->sender(),
+            $outbox->emailOngoingRun?->email?->subject,
+            $emailHtmlBody,
+            ''
+        );
+    }
+
+
+
+}

--- a/app/Actions/Comms/Email/SendPalletReturnDispatchedNotification.php
+++ b/app/Actions/Comms/Email/SendPalletReturnDispatchedNotification.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Author: Ganes <gustiganes@gmail.com>
+ * Created on: 21-03-2025, Bali, Indonesia
+ * Github: https://github.com/Ganes556
+ * Copyright: 2025
+ *
+*/
+
+namespace App\Actions\Comms\Email;
+
+use App\Actions\Comms\DispatchedEmail\StoreDispatchedEmail;
+use App\Actions\Comms\Traits\WithSendBulkEmails;
+use App\Actions\OrgAction;
+use App\Actions\Traits\Rules\WithNoStrictRules;
+use App\Actions\Traits\WithActionUpdate;
+use App\Enums\Comms\DispatchedEmail\DispatchedEmailProviderEnum;
+use App\Enums\Comms\Outbox\OutboxBuilderEnum;
+use App\Enums\Comms\Outbox\OutboxCodeEnum;
+use App\Enums\Comms\Outbox\OutboxTypeEnum;
+use App\Models\Comms\DispatchedEmail;
+use App\Models\Comms\Email;
+use App\Models\CRM\Customer;
+use Illuminate\Support\Arr;
+
+class SendPalletReturnDispatchedNotification extends OrgAction
+{
+    use WithActionUpdate;
+    use WithNoStrictRules;
+    use WithSendBulkEmails;
+
+    private Email $email;
+
+    public function handle(Customer $customer): DispatchedEmail
+    {
+
+        $outbox = $customer->shop->outboxes()->where('code', OutboxCodeEnum::PALLET_RETURN_DISPATCHED->value)->first();
+        $outboxDispatch = $customer->shop->outboxes()->where('type', OutboxTypeEnum::CUSTOMER_NOTIFICATION)->first();
+
+        $recipient       = $customer;
+        $dispatchedEmail = StoreDispatchedEmail::run($outbox->emailOngoingRun, $recipient, [
+            'is_test'       => false,
+            'outbox_id'     => $outboxDispatch->id,
+            'email_address' => $recipient->email,
+            'provider'      => DispatchedEmailProviderEnum::SES
+        ]);
+        $dispatchedEmail->refresh();
+
+        if ($outbox->builder == OutboxBuilderEnum::BLADE) {
+            $emailHtmlBody = Arr::get($outbox->emailOngoingRun?->email?->liveSnapshot?->layout, 'blade_template');
+        } else {
+            $emailHtmlBody = $outbox->emailOngoingRun?->email?->liveSnapshot?->compiled_layout;
+        }
+
+        return $this->sendEmailWithMergeTags(
+            $dispatchedEmail,
+            $outbox->emailOngoingRun->sender(),
+            $outbox->emailOngoingRun?->email?->subject,
+            $emailHtmlBody,
+            ''
+        );
+    }
+
+
+
+}

--- a/app/Actions/Fulfilment/PalletDelivery/StorePalletDelivery.php
+++ b/app/Actions/Fulfilment/PalletDelivery/StorePalletDelivery.php
@@ -9,6 +9,7 @@
 namespace App\Actions\Fulfilment\PalletDelivery;
 
 use App\Actions\Catalogue\HasRentalAgreement;
+use App\Actions\Comms\Email\SendPalletDeliveryProcessedNotification;
 use App\Actions\Fulfilment\Fulfilment\Hydrators\FulfilmentHydratePalletDeliveries;
 use App\Actions\Fulfilment\FulfilmentCustomer\Hydrators\FulfilmentCustomerHydratePalletDeliveries;
 use App\Actions\Fulfilment\PalletDelivery\Notifications\SendPalletDeliveryNotification;
@@ -77,6 +78,7 @@ class StorePalletDelivery extends OrgAction
 
 
         SendPalletDeliveryNotification::dispatch($palletDelivery);
+        SendPalletDeliveryProcessedNotification::dispatch($palletDelivery->fulfilmentCustomer->customer);
 
         return $palletDelivery;
     }

--- a/app/Actions/Fulfilment/PalletReturn/DispatchPalletReturn.php
+++ b/app/Actions/Fulfilment/PalletReturn/DispatchPalletReturn.php
@@ -8,6 +8,7 @@
 
 namespace App\Actions\Fulfilment\PalletReturn;
 
+use App\Actions\Comms\Email\SendPalletReturnDispatchedNotification;
 use App\Actions\Dropshipping\Shopify\Fulfilment\DispatchFulfilmentOrderShopify;
 use App\Actions\Fulfilment\Fulfilment\Hydrators\FulfilmentHydratePalletReturns;
 use App\Actions\Fulfilment\FulfilmentCustomer\Hydrators\FulfilmentCustomerHydratePalletReturns;
@@ -87,6 +88,7 @@ class DispatchPalletReturn extends OrgAction
         FulfilmentHydratePalletReturns::dispatch($palletReturn->fulfilment);
         SendPalletReturnNotification::run($palletReturn);
         PalletReturnRecordSearch::dispatch($palletReturn);
+        SendPalletReturnDispatchedNotification::dispatch($palletReturn->fulfilmentCustomer->customer);
 
         return $palletReturn;
     }


### PR DESCRIPTION
 
 
 **PR Summary by Typo**
------------

**Overview:**
This PR implements email notifications for pallet return and pallet delivery events.  It introduces two new email actions, `SendPalletReturnDispatchedNotification` and `SendPalletDeliveryProcessedNotification`, and integrates them into the respective workflows.

**Key Changes:**
- Added `SendPalletReturnDispatchedNotification` action and integrated it into `DispatchPalletReturn`.
- Added `SendPalletDeliveryProcessedNotification` action and integrated it into `StorePalletDelivery`.
- Created new files for the email actions.
- Modified `SendNewCustomerNotification` (minor unrelated change).

**Recommendations:**
Not deployment ready.  While the core functionality seems implemented, the PR lacks clarity on the email templates used and how they are configured.  Provide more details on the email content and ensure the outbox configuration is properly documented.  Additionally, consider adding unit tests to verify the notification logic and error handling within the new actions.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>