### PR TITLE
1555 pallet return address

### DIFF
--- a/app/Actions/Fulfilment/PalletReturn/UI/ShowPalletReturn.php
+++ b/app/Actions/Fulfilment/PalletReturn/UI/ShowPalletReturn.php
@@ -558,6 +558,7 @@ class ShowPalletReturn extends OrgAction
                 ],
                 'data'             => PalletReturnResource::make($palletReturn),
                 'box_stats'        => [
+                    'collection_notes'  => $palletReturn->collection_notes ?? '',
                     'recurring_bill'      => $recurringBillData,
                     'fulfilment_customer'          => array_merge(
                         FulfilmentCustomerResource::make($palletReturn->fulfilmentCustomer)->getArray(),

--- a/app/Actions/Fulfilment/PalletReturn/UI/ShowStoredItemReturn.php
+++ b/app/Actions/Fulfilment/PalletReturn/UI/ShowStoredItemReturn.php
@@ -423,6 +423,7 @@ class ShowStoredItemReturn extends OrgAction
                 ],
                 'data'       => PalletReturnResource::make($palletReturn),
                 'box_stats'  => [
+                    'collection_notes'  => $palletReturn->collection_notes ?? '',
                     'recurring_bill'      => $recurringBillData,
                     'fulfilment_customer' => array_merge(
                         FulfilmentCustomerResource::make($palletReturn->fulfilmentCustomer)->getArray(),

--- a/app/Actions/Fulfilment/PalletReturn/UpdatePalletReturn.php
+++ b/app/Actions/Fulfilment/PalletReturn/UpdatePalletReturn.php
@@ -99,7 +99,11 @@ class UpdatePalletReturn extends OrgAction
                 ->ignore($this->palletReturn->id)],
             'customer_notes'      => ['sometimes', 'nullable', 'string', 'max:5000'],
             'address'             => ['sometimes'],
-            'delivery_address_id' => ['sometimes', Rule::exists('addresses', 'id')]
+            'delivery_address_id' => ['sometimes', Rule::exists('addresses', 'id')],
+            'reference'      => ['sometimes', 'string', 'max:255'],
+            'public_notes'   => ['sometimes', 'nullable', 'string', 'max:4000'],
+            'internal_notes' => ['sometimes', 'nullable', 'string', 'max:4000'],
+            'collection_notes' => ['sometimes', 'nullable', 'string', 'max:4000'],
         ];
     }
 

--- a/app/Actions/Retina/Fulfilment/PalletReturn/UI/ShowRetinaPalletReturn.php
+++ b/app/Actions/Retina/Fulfilment/PalletReturn/UI/ShowRetinaPalletReturn.php
@@ -310,6 +310,7 @@ class ShowRetinaPalletReturn extends RetinaAction
                     'navigation' => $navigation
                 ],
                 'box_stats'  => [
+                    'collection_notes'  => $palletReturn->collection_notes ?? '',
                     'fulfilment_customer' => array_merge(
                         FulfilmentCustomerResource::make($palletReturn->fulfilmentCustomer)->getArray(),
                         [

--- a/app/Actions/Retina/Fulfilment/PalletReturn/UI/ShowRetinaStoredItemReturn.php
+++ b/app/Actions/Retina/Fulfilment/PalletReturn/UI/ShowRetinaStoredItemReturn.php
@@ -281,6 +281,7 @@ class ShowRetinaStoredItemReturn extends RetinaAction
                     'navigation' => $navigation
                 ],
                 'box_stats'        => [
+                    'collection_notes'  => $palletReturn->collection_notes ?? '',
                     'fulfilment_customer'          => array_merge(
                         FulfilmentCustomerResource::make($palletReturn->fulfilmentCustomer)->getArray(),
                         [

--- a/app/Actions/Retina/Fulfilment/PalletReturn/UpdateRetinaPalletReturn.php
+++ b/app/Actions/Retina/Fulfilment/PalletReturn/UpdateRetinaPalletReturn.php
@@ -46,6 +46,7 @@ class UpdateRetinaPalletReturn extends RetinaAction
             'public_notes'   => ['sometimes', 'nullable', 'string', 'max:4000'],
             'customer_notes'   => ['sometimes', 'nullable', 'string', 'max:4000'],
             'internal_notes' => ['sometimes', 'nullable', 'string', 'max:4000'],
+            'collection_notes' => ['sometimes', 'nullable', 'string', 'max:4000'],
         ];
     }
 

--- a/database/migrations/2025_03_20_052647_add_collection_notes_to_pallet_returns_table.php
+++ b/database/migrations/2025_03_20_052647_add_collection_notes_to_pallet_returns_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pallet_returns', function (Blueprint $table) {
+            $table->text('collection_notes')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pallet_returns', function (Blueprint $table) {
+            $table->dropColumn('collection_notes');
+        });
+    }
+};

--- a/resources/js/Components/Retina/Storage/RetinaBoxStatsReturn.vue
+++ b/resources/js/Components/Retina/Storage/RetinaBoxStatsReturn.vue
@@ -130,7 +130,7 @@ const computedEnabled = computed({
 
 function updateCollectionNotes() {
 	router.patch(
-		route(props.updateRoute.name, props.updateRoute.parameters),
+		route(props.updateRoute.route.name, props.updateRoute.route.parameters),
 		{ collection_notes: textValue.value },
 		{
 			preserveScroll: true,

--- a/resources/js/Components/Retina/Storage/RetinaBoxStatsReturn.vue
+++ b/resources/js/Components/Retina/Storage/RetinaBoxStatsReturn.vue
@@ -10,8 +10,9 @@ import { router } from '@inertiajs/vue3'
 import Popover from '@/Components/Popover.vue'
 import { PalletDelivery, BoxStats, PalletReturn, PDRNotes } from '@/types/Pallet'
 import Modal from '@/Components/Utils/Modal.vue'
+import { Switch, SwitchGroup, SwitchLabel } from "@headlessui/vue"
 
-import { inject, ref } from 'vue'
+import { computed, inject, ref } from 'vue'
 import { capitalize } from '@/Composables/capitalize'
 import { routeType } from "@/types/route"
 import LoadingIcon from "@/Components/Utils/LoadingIcon.vue"
@@ -19,6 +20,7 @@ import { layoutStructure } from "@/Composables/useLayoutStructure"
 import RetinaBoxNote from "@/Components/Retina/Storage/RetinaBoxNote.vue"
 import OrderSummary from "@/Components/Summary/OrderSummary.vue"
 import ModalAddress from '@/Components/Utils/ModalAddress.vue'
+import Textarea from "primevue/textarea"
 
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faBuilding, faIdCardAlt, faMapMarkerAlt, faPenSquare } from '@fal'
@@ -44,7 +46,111 @@ const layout = inject('layout', layoutStructure)
 
 const isModalAddress = ref(false)
 const isModalAddressCollection = ref(false)
-console.log('fff', props.box_stats)
+const enabled = ref(props.data_pallet.is_collection || false)
+const isLoading = ref<string | boolean>(false)
+const textValue = ref(props.box_stats.collection_notes)
+
+// Computed property to intercept changes via v-model
+const computedEnabled = computed({
+	get() {
+		return enabled.value
+	},
+	set(newValue: boolean) {
+		const addressID = props.box_stats.fulfilment_customer.address?.address_customer?.value.id
+		const address = props.box_stats.fulfilment_customer.address?.address_customer?.value
+
+		if (!newValue) {
+			// Prepare the address data for creating a new record.
+			const filterDataAddress = { ...address }
+			delete filterDataAddress.formatted_address
+			delete filterDataAddress.country
+			delete filterDataAddress.id // Remove id to create a new one
+
+			router[
+				props.box_stats.fulfilment_customer.address.routes_address.store.method || "post"
+			](
+				route(
+					props.box_stats.fulfilment_customer.address.routes_address.store.name,
+					props.box_stats.fulfilment_customer.address.routes_address.store.parameters
+				),
+				{
+					delivery_address: filterDataAddress,
+				},
+				{
+					preserveScroll: true,
+					onFinish: () => {},
+					onSuccess: () => {
+						notify({
+							title: trans("Success"),
+							text: trans("Set the address to selected address."),
+							type: "success",
+						})
+					},
+					onError: () =>
+						notify({
+							title: trans("Something went wrong"),
+							text: trans("Failed to submit the address, try again"),
+							type: "error",
+						}),
+				}
+			)
+		} else {
+			try {
+				router.delete(
+					route(props.box_stats.fulfilment_customer.address.routes_address.delete.name, {
+						...props.box_stats.fulfilment_customer.address.routes_address.delete
+							.parameters,
+					}),
+					{
+						preserveScroll: true,
+						onStart: () => (isLoading.value = "onDelete" + addressID),
+						onFinish: () => {
+							isLoading.value = false
+						},
+					}
+				)
+				notify({
+					title: trans("Success"),
+					text: trans("Set the address to follow collection."),
+					type: "success",
+				})
+			} catch (error) {
+				console.error("Error disabling collection:", error)
+				notify({
+					title: trans("Something went wrong"),
+					text: trans("Failed to disable collection."),
+					type: "error",
+				})
+			}
+		}
+		// Finally, update the ref value.
+		enabled.value = newValue
+	},
+})
+
+function updateCollectionNotes() {
+	router.patch(
+		route(props.updateRoute.name, props.updateRoute.parameters),
+		{ collection_notes: textValue.value },
+		{
+			preserveScroll: true,
+			onSuccess: () => {
+				notify({
+					title: trans("Success"),
+					text: trans("Text updated successfully"),
+					type: "success",
+				})
+			},
+			onError: () => {
+				notify({
+					title: trans("Something went wrong"),
+					text: trans("Failed to update text"),
+					type: "error",
+				})
+			},
+		}
+	)
+}
 
 // Method: On change estimated date
 // const onChangeEstimateDate = async (close: Function) => {
@@ -125,38 +231,63 @@ console.log('fff', props.box_stats)
             </div>
             
             <!-- Field: Delivery Address -->
-            <div class="flex items-start w-full flex-none gap-x-2 mb-1">
-                <dt v-tooltip="`Pallet Return's address`" class="flex-none">
-                    <span class="sr-only">Delivery address</span>
-                    <FontAwesomeIcon icon='fal fa-map-marker-alt' size="xs" class='text-gray-400' fixed-width
-                        aria-hidden='true' />
-                </dt>
-
-                <dd v-if="data_pallet.is_collection !== true" class=" w-full text-xs text-gray-500">
-                    <div class="relative px-2.5 py-2 ring-1 ring-gray-300 rounded bg-gray-50">
-                        <span class="" v-html="box_stats.fulfilment_customer.address.value.formatted_address" />
-
-                        <div @click="() => isModalAddressCollection = true"
-                            class="whitespace-nowrap select-none text-gray-500 hover:text-blue-600 underline cursor-pointer">
-                            <span>Edit</span>
-                        </div>
-                    </div>
-                </dd>
-                <div v-else>
-					<span>For collection </span>
-					<span @click="() => (isModalAddressCollection = true)">
+            <div class="flex flex-col w-full gap-y-2 mb-1">
+				<!-- Top Row: Icon and Switch -->
+				<div class="flex items-center gap-x-2">
+					<dt v-tooltip="trans('Pallet Return\'s address')" class="flex-none">
+						<span class="sr-only">Delivery address</span>
 						<FontAwesomeIcon
-							icon="fal fa-pen-square"
-							size="lg"
-							class="text-gray-400 cursor-pointer"
+							icon="fal fa-map-marker-alt"
+							size="xs"
+							class="text-gray-400"
 							fixed-width
 							aria-hidden="true" />
-					</span>
+					</dt>
+					<SwitchGroup as="div" class="flex items-center">
+						<Switch
+							v-model="computedEnabled"
+							:class="[computedEnabled ? 'bg-indigo-600' : 'bg-gray-200']"
+							class="relative inline-flex h-6 w-11 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2">
+							<span
+								aria-hidden="true"
+								:class="[computedEnabled ? 'translate-x-5' : 'translate-x-0']"
+								class="pointer-events-none inline-block h-5 w-5 transform bg-white rounded-full shadow transition duration-200 ease-in-out" />
+						</Switch>
+						<SwitchLabel as="span" class="ml-3 text-sm font-medium text-gray-900">
+							{{ trans("Collection") }}
+						</SwitchLabel>
+					</SwitchGroup>
 				</div>
-                <!-- <div v-else @click="() => isModalAddress = true" class="leading-6  inline whitespace-nowrap select-none text-gray-500 hover:text-blue-600 underline cursor-pointer">
-                    Setup delivery address
-                </div> -->
-            </div>
+
+				<!-- Bottom Row: Address Display -->
+				<div
+					v-if="data_pallet.is_collection !== true"
+					class="w-full text-xs text-gray-500">
+					<div class="relative px-2.5 py-2 ring-1 ring-gray-300 rounded bg-gray-50">
+						<span
+							v-html="
+                            box_stats.fulfilment_customer?.address?.value?.formatted_address
+							" />
+						<div
+							@click="() => (isModalAddressCollection = true)"
+							class="whitespace-nowrap select-none text-gray-500 hover:text-blue-600 underline cursor-pointer">
+							<span>Edit</span>
+						</div>
+					</div>
+				</div>
+
+				<!-- Alternative Display for Collection -->
+				<div v-else class="w-full">
+					<Textarea
+						v-model="textValue"
+						@blur="updateCollectionNotes"
+						autoResize
+						rows="5"
+						class="w-full"
+						cols="30"
+						placeholder="typing..." />
+				</div>
+			</div>
         </BoxStatPallet>
 
 

--- a/resources/js/Components/Utils/ModalAddressCollection.vue
+++ b/resources/js/Components/Utils/ModalAddressCollection.vue
@@ -180,6 +180,8 @@ watch(enabled, async (newValue) => {
 	const addressID = props.addresses?.address_customer?.value.id
 	const address = props.addresses?.address_customer?.value
 	if (!newValue) {
+		console.log('xxxxx', address);
+		
 		const filterDataAdddress = { ...address }
 		delete filterDataAdddress.formatted_address
 		delete filterDataAdddress.country
@@ -257,27 +259,7 @@ watch(enabled, async (newValue) => {
 				{{ trans("Delivery Address ") }}
 			</div>
 		</div>
-
-		<div class="relative transition-all"></div>
-		<div class="flex items-center justify-between space-x-4 p-4 rounded-lg shadow-sm">
-			<SwitchGroup as="div" class="flex items-center">
-				<Switch
-					v-model="enabled"
-					:class="[enabled ? 'bg-indigo-600' : 'bg-gray-200']"
-					class="relative inline-flex h-6 w-11 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2">
-					<span
-						aria-hidden="true"
-						:class="[enabled ? 'translate-x-5' : 'translate-x-0']"
-						class="pointer-events-none inline-block h-5 w-5 transform bg-white rounded-full shadow transition duration-200 ease-in-out" />
-				</Switch>
-				<SwitchLabel as="span" class="ml-3 text-sm font-medium text-gray-900">
-					{{ trans("Collection") }}
-				</SwitchLabel>
-			</SwitchGroup>
-		</div>
-
 		<div
-			v-if="!enabled"
 			:key="'edit' + selectedAddress?.id"
 			class="col-span-2 relative py-4 h-fit grid grid-cols-2 gap-x-4">
 			<div
@@ -302,7 +284,6 @@ watch(enabled, async (newValue) => {
 				</div>
 			</div>
 		</div>
-		<div v-else></div>
 	</div>
 </template>
 

--- a/resources/js/Pages/Grp/Org/Fulfilment/Return/BoxStatsPalletReturn.vue
+++ b/resources/js/Pages/Grp/Org/Fulfilment/Return/BoxStatsPalletReturn.vue
@@ -6,27 +6,30 @@
 
 <script setup lang="ts">
 import JsBarcode from "jsbarcode"
-import { onMounted, ref } from "vue"
+import { computed, onMounted, ref, watch } from "vue"
 import { capitalize } from "@/Composables/capitalize"
 import ModalAddress from "@/Components/Utils/ModalAddress.vue"
 
 import { PalletReturn, BoxStats } from "@/types/Pallet"
-import { Link } from "@inertiajs/vue3"
+import { Link, router } from "@inertiajs/vue3"
 import BoxStatPallet from "@/Components/Pallet/BoxStatPallet.vue"
 import { trans } from "laravel-vue-i18n"
 
 import Modal from "@/Components/Utils/Modal.vue"
 import { routeType } from "@/types/route"
 import OrderSummary from "@/Components/Summary/OrderSummary.vue"
+import { Switch, SwitchGroup, SwitchLabel } from "@headlessui/vue"
 
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome"
 import { faQuestionCircle, faPencil, faPenSquare } from "@fal"
 import { library } from "@fortawesome/fontawesome-svg-core"
 import ModalAddressCollection from "@/Components/Utils/ModalAddressCollection.vue"
 import PalletEditCustomerReference from "@/Components/Pallet/PalletEditCustomerReference.vue"
+import { notify } from "@kyvg/vue3-notification"
+import Textarea from "primevue/textarea"
 library.add(faQuestionCircle, faPencil, faPenSquare)
 
-defineProps<{
+const props = defineProps<{
 	dataPalletReturn: PalletReturn
 	boxStats: BoxStats
 	updateRoute: routeType
@@ -44,6 +47,126 @@ onMounted(() => {
 // Method: Create new address
 const isModalAddress = ref(false)
 const isModalAddressCollection = ref(false)
+const enabled = ref(props.dataPalletReturn.is_collection || false)
+const isLoading = ref<string | boolean>(false)
+const textValue = ref("")
+const textUpdateTimeout = ref<number | null>(null)
+
+// Computed property to intercept changes via v-model
+const computedEnabled = computed({
+	get() {
+		return enabled.value
+	},
+	set(newValue: boolean) {
+		const addressID = props.boxStats.fulfilment_customer.address?.address_customer?.value.id
+		const address = props.boxStats.fulfilment_customer.address?.address_customer?.value
+
+		if (!newValue) {
+			// Prepare the address data for creating a new record.
+			const filterDataAddress = { ...address }
+			delete filterDataAddress.formatted_address
+			delete filterDataAddress.country
+			delete filterDataAddress.id // Remove id to create a new one
+
+			router[
+				props.boxStats.fulfilment_customer.address.routes_address.store.method || "post"
+			](
+				route(
+					props.boxStats.fulfilment_customer.address.routes_address.store.name,
+					props.boxStats.fulfilment_customer.address.routes_address.store.parameters
+				),
+				{
+					delivery_address: filterDataAddress,
+				},
+				{
+					preserveScroll: true,
+					onFinish: () => {},
+					onSuccess: () => {
+						notify({
+							title: trans("Success"),
+							text: trans("Set the address to selected address."),
+							type: "success",
+						})
+					},
+					onError: () =>
+						notify({
+							title: trans("Something went wrong"),
+							text: trans("Failed to submit the address, try again"),
+							type: "error",
+						}),
+				}
+			)
+		} else {
+			try {
+				router.delete(
+					route(props.boxStats.fulfilment_customer.address.routes_address.delete.name, {
+						...props.boxStats.fulfilment_customer.address.routes_address.delete
+							.parameters,
+					}),
+					{
+						preserveScroll: true,
+						onStart: () => (isLoading.value = "onDelete" + addressID),
+						onFinish: () => {
+							isLoading.value = false
+						},
+					}
+				)
+				notify({
+					title: trans("Success"),
+					text: trans("Set the address to follow collection."),
+					type: "success",
+				})
+			} catch (error) {
+				console.error("Error disabling collection:", error)
+				notify({
+					title: trans("Something went wrong"),
+					text: trans("Failed to disable collection."),
+					type: "error",
+				})
+			}
+		}
+		// Finally, update the ref value.
+		enabled.value = newValue
+	},
+})
+
+const computedText = computed({
+	get() {
+		return textValue.value
+	},
+	set(newValue: string) {
+		textValue.value = newValue
+
+		// Clear any existing debounce timer.
+		if (textUpdateTimeout.value) {
+			clearTimeout(textUpdateTimeout.value)
+		}
+
+		textUpdateTimeout.value = setTimeout(() => {
+			router.patch(
+				route(props.updateRoute.name, props.updateRoute.parameters),
+				{ collection_notes: textValue.value },
+				{
+					preserveScroll: true,
+					onSuccess: () => {
+						notify({
+							title: trans("Success"),
+							text: trans("Text updated successfully"),
+							type: "success",
+						})
+					},
+					onError: () => {
+						notify({
+							title: trans("Something went wrong"),
+							text: trans("Failed to update text"),
+							type: "error",
+						})
+					},
+				}
+			)
+		}, 500) as unknown as number // Type assertion for browser compatibility.
+	},
+})
 </script>
 
 <template>
@@ -144,43 +267,54 @@ const isModalAddressCollection = ref(false)
 			</div>
 
 			<!-- Field: Delivery Address -->
-			<div class="flex items-start w-full flex-none gap-x-2 mb-1">
-				<dt v-tooltip="trans(`Pallet Return's address`)" class="flex-none">
-					<span class="sr-only">Delivery address</span>
-					<FontAwesomeIcon
-						icon="fal fa-map-marker-alt"
-						size="xs"
-						class="text-gray-400"
-						fixed-width
-						aria-hidden="true" />
-				</dt>
+			<div class="flex flex-col w-full gap-y-2 mb-1">
+				<!-- Top Row: Icon and Switch -->
+				<div class="flex items-center gap-x-2">
+					<dt v-tooltip="trans('Pallet Return\'s address')" class="flex-none">
+						<span class="sr-only">Delivery address</span>
+						<FontAwesomeIcon
+							icon="fal fa-map-marker-alt"
+							size="xs"
+							class="text-gray-400"
+							fixed-width
+							aria-hidden="true" />
+					</dt>
+					<SwitchGroup as="div" class="flex items-center">
+						<Switch
+							v-model="computedEnabled"
+							:class="[computedEnabled ? 'bg-indigo-600' : 'bg-gray-200']"
+							class="relative inline-flex h-6 w-11 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2">
+							<span
+								aria-hidden="true"
+								:class="[computedEnabled ? 'translate-x-5' : 'translate-x-0']"
+								class="pointer-events-none inline-block h-5 w-5 transform bg-white rounded-full shadow transition duration-200 ease-in-out" />
+						</Switch>
+						<SwitchLabel as="span" class="ml-3 text-sm font-medium text-gray-900">
+							{{ trans("Collection") }}
+						</SwitchLabel>
+					</SwitchGroup>
+				</div>
 
-				<dd
+				<!-- Bottom Row: Address Display -->
+				<div
 					v-if="dataPalletReturn.is_collection !== true"
 					class="w-full text-xs text-gray-500">
 					<div class="relative px-2.5 py-2 ring-1 ring-gray-300 rounded bg-gray-50">
 						<span
-							class=""
-							v-html="boxStats.fulfilment_customer?.address?.value?.formatted_address" />
-
+							v-html="
+								boxStats.fulfilment_customer?.address?.value?.formatted_address
+							" />
 						<div
 							@click="() => (isModalAddressCollection = true)"
 							class="whitespace-nowrap select-none text-gray-500 hover:text-blue-600 underline cursor-pointer">
-							<!-- <FontAwesomeIcon icon='fal fa-pencil' size="sm" class='mr-1' fixed-width aria-hidden='true' /> -->
 							<span>Edit</span>
 						</div>
 					</div>
-				</dd>
-				<div v-else>
-					<span>For collection </span>
-					<span @click="() => (isModalAddressCollection = true)">
-						<FontAwesomeIcon
-							icon="fal fa-pen-square"
-							size="sm"
-							class="text-gray-400 cursor-pointer"
-							fixed-width
-							aria-hidden="true" />
-					</span>
+				</div>
+
+				<!-- Alternative Display for Collection -->
+				<div v-else class="w-full">
+					<Textarea  v-model="computedText" autoResize rows="5" class="w-full" cols="30" />
 				</div>
 			</div>
 		</BoxStatPallet>
@@ -191,13 +325,10 @@ const isModalAddressCollection = ref(false)
 			:label="capitalize(dataPalletReturn?.state)"
 			icon="fal fa-truck-couch">
 			<!-- Customer reference -->
-            <div class="mb-1">
-                <PalletEditCustomerReference
-                    :dataPalletDelivery="dataPalletReturn"
-                    :updateRoute
-                />
-					<!-- :disabled="dataPalletReturn?.state !== 'in_process' && dataPalletReturn?.state !== 'submit'"-->
-            </div>
+			<div class="mb-1">
+				<PalletEditCustomerReference :dataPalletDelivery="dataPalletReturn" :updateRoute />
+				<!-- :disabled="dataPalletReturn?.state !== 'in_process' && dataPalletReturn?.state !== 'submit'"-->
+			</div>
 
 			<!-- Barcode -->
 			<div
@@ -254,17 +385,30 @@ const isModalAddressCollection = ref(false)
 		</BoxStatPallet>
 
 		<!-- Box: Order summary -->
-		<BoxStatPallet v-if="boxStats?.order_summary" class="sm:col-span-2 border-t sm:border-t-0 border-gray-300">
+		<BoxStatPallet
+			v-if="boxStats?.order_summary"
+			class="sm:col-span-2 border-t sm:border-t-0 border-gray-300">
 			<section
 				aria-labelledby="summary-heading"
 				class="lg:max-w-xl rounded-lg px-4 py-4 sm:px-6 lg:mt-0">
 				<!-- <h2 id="summary-heading" class="text-lg font-medium">Order summary</h2> -->
 				<div class="text-gray-500 mb-2" v-if="boxStats?.recurring_bill">
-					<Link :href="route(boxStats?.recurring_bill?.route?.name,boxStats?.recurring_bill?.route?.parameters)" method="get" v-tooltip="'Recurring Bill'" class="primaryLink">
+					<Link
+						:href="
+							route(
+								boxStats?.recurring_bill?.route?.name,
+								boxStats?.recurring_bill?.route?.parameters
+							)
+						"
+						method="get"
+						v-tooltip="'Recurring Bill'"
+						class="primaryLink">
 						{{ boxStats?.recurring_bill?.reference }}
 					</Link>
 				</div>
-				<OrderSummary :order_summary="boxStats.order_summary" :currency_code="boxStats.order_summary.currency.data.code" />
+				<OrderSummary
+					:order_summary="boxStats.order_summary"
+					:currency_code="boxStats.order_summary.currency.data.code" />
 			</section>
 		</BoxStatPallet>
 	</div>
@@ -274,7 +418,10 @@ const isModalAddressCollection = ref(false)
 	</Modal>
 
 	<Modal :isOpen="isModalAddressCollection" @onClose="() => (isModalAddressCollection = false)">
-		<ModalAddressCollection :addresses="boxStats.fulfilment_customer.address" :updateRoute :is_collection="dataPalletReturn.is_collection" />
+		<ModalAddressCollection
+			:addresses="boxStats.fulfilment_customer.address"
+			:updateRoute
+			:is_collection="dataPalletReturn.is_collection" />
 	</Modal>
 </template>
 

--- a/resources/js/Pages/Grp/Org/Fulfilment/Return/BoxStatsPalletReturn.vue
+++ b/resources/js/Pages/Grp/Org/Fulfilment/Return/BoxStatsPalletReturn.vue
@@ -34,6 +34,7 @@ const props = defineProps<{
 	boxStats: BoxStats
 	updateRoute: routeType
 }>()
+console.log(props.boxStats,'asd');
 
 onMounted(() => {
 	JsBarcode("#palletReturnBarcode", route().v().params.palletReturn, {
@@ -49,7 +50,7 @@ const isModalAddress = ref(false)
 const isModalAddressCollection = ref(false)
 const enabled = ref(props.dataPalletReturn.is_collection || false)
 const isLoading = ref<string | boolean>(false)
-const textValue = ref("")
+const textValue = ref(props.boxStats.collection_notes)
 const textUpdateTimeout = ref<number | null>(null)
 
 // Computed property to intercept changes via v-model

--- a/resources/js/Pages/Grp/Org/Fulfilment/Return/BoxStatsPalletReturn.vue
+++ b/resources/js/Pages/Grp/Org/Fulfilment/Return/BoxStatsPalletReturn.vue
@@ -34,7 +34,7 @@ const props = defineProps<{
 	boxStats: BoxStats
 	updateRoute: routeType
 }>()
-console.log(props.boxStats,'asd');
+console.log(props.boxStats, "asd")
 
 onMounted(() => {
 	JsBarcode("#palletReturnBarcode", route().v().params.palletReturn, {
@@ -51,7 +51,6 @@ const isModalAddressCollection = ref(false)
 const enabled = ref(props.dataPalletReturn.is_collection || false)
 const isLoading = ref<string | boolean>(false)
 const textValue = ref(props.boxStats.collection_notes)
-const textUpdateTimeout = ref<number | null>(null)
 
 // Computed property to intercept changes via v-model
 const computedEnabled = computed({
@@ -131,43 +130,29 @@ const computedEnabled = computed({
 	},
 })
 
-const computedText = computed({
-	get() {
-		return textValue.value
-	},
-	set(newValue: string) {
-		textValue.value = newValue
-
-		// Clear any existing debounce timer.
-		if (textUpdateTimeout.value) {
-			clearTimeout(textUpdateTimeout.value)
+function updateCollectionNotes() {
+	router.patch(
+		route(props.updateRoute.name, props.updateRoute.parameters),
+		{ collection_notes: textValue.value },
+		{
+			preserveScroll: true,
+			onSuccess: () => {
+				notify({
+					title: trans("Success"),
+					text: trans("Text updated successfully"),
+					type: "success",
+				})
+			},
+			onError: () => {
+				notify({
+					title: trans("Something went wrong"),
+					text: trans("Failed to update text"),
+					type: "error",
+				})
+			},
 		}
-
-		textUpdateTimeout.value = setTimeout(() => {
-			router.patch(
-				route(props.updateRoute.name, props.updateRoute.parameters),
-				{ collection_notes: textValue.value },
-				{
-					preserveScroll: true,
-					onSuccess: () => {
-						notify({
-							title: trans("Success"),
-							text: trans("Text updated successfully"),
-							type: "success",
-						})
-					},
-					onError: () => {
-						notify({
-							title: trans("Something went wrong"),
-							text: trans("Failed to update text"),
-							type: "error",
-						})
-					},
-				}
-			)
-		}, 500) as unknown as number // Type assertion for browser compatibility.
-	},
-})
+	)
+}
 </script>
 
 <template>
@@ -315,7 +300,14 @@ const computedText = computed({
 
 				<!-- Alternative Display for Collection -->
 				<div v-else class="w-full">
-					<Textarea  v-model="computedText" autoResize rows="5" class="w-full" cols="30" />
+					<Textarea
+						v-model="textValue"
+						@blur="updateCollectionNotes"
+						autoResize
+						rows="5"
+						class="w-full"
+						cols="30"
+						placeholder="typing..." />
 				</div>
 			</div>
 		</BoxStatPallet>


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR adds a "collection_notes" field to the pallet returns, allowing users to add notes for collections.  It also introduces a toggle for "Collection" which, when enabled, hides the delivery address and displays the collection notes textarea.  The UI is updated to reflect these changes across different components.

**Key Changes**
- Added a migration to create the `collection_notes` column in the `pallet_returns` table.
- Added `collection_notes` to the API responses for pallet returns.
- Implemented the collection toggle and associated UI logic in multiple components.
- Updated validation rules to include `collection_notes`.
- Added UI elements for displaying and editing collection notes.

**Recommendations**
Not deployment ready. While the functionality seems implemented, consider adding unit tests to cover the new logic around the collection toggle and notes updates.  Also, review the error handling around updating `collection_notes` to ensure it meets production standards.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>