### PR TITLE
get shipping zone for order

### DIFF
--- a/app/Actions/Ordering/Order/GetShippingAmount.php
+++ b/app/Actions/Ordering/Order/GetShippingAmount.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Wed, 02 Apr 2025 17:03:43 Malaysia Time, Kuala Lumpur, Malaysia
+ * Copyright (c) 2025, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\Ordering\Order;
+
+use App\Models\Ordering\Order;
+use Illuminate\Support\Arr;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class GetShippingAmount
+{
+    use AsAction;
+
+    public function handle(Order $order, $discount = false): array
+    {
+
+        $shippingZone = GetShippingZone::run($order, $discount);
+        if (!$shippingZone) {
+            return [null,0];
+        }
+
+
+        $pricing = $shippingZone->price;
+
+        return match (Arr::get($pricing, 'type')) {
+            'Step Order Items Net Amount' => [
+                $shippingZone,
+                $this->getShippingAmountFromStepAmount($order->goods_amount, $pricing)
+            ],
+            'Step Order Estimated Weight' => [
+                $shippingZone,
+                $this->getShippingAmountFromStepAmount($order->estimated_weight, $pricing)
+            ],
+            default => [$shippingZone, 0],
+        };
+
+
+    }
+
+    private function getShippingAmountFromStepAmount($amount, array $pricing): float|int
+    {
+        $shippingAmount = 0;
+        $steps = Arr::get($pricing, 'steps', []);
+
+        foreach ($steps as $step) {
+            $from = floatval($step['from']);
+            $to = $step['to'] === 'INF' ? INF : floatval($step['to']);
+
+            if ($amount >= $from && $amount < $to) {
+                $shippingAmount = floatval($step['price']);
+                break;
+            }
+        }
+
+        return $shippingAmount;
+    }
+
+
+//    public string $commandSignature = 'order:get-shipping-amount {order? : The ID of the order}';
+//
+//    public function commandProcess(Command $command, Order $order): void
+//    {
+//        list($shippingZone, $shippingAmount) = $this->handle($order);
+//
+//        $command->info('Shipping: '.$shippingAmount.' '.$shippingZone?->name);
+//
+//
+//    }
+//
+//    public function asCommand(Command $command): int
+//    {
+//        if ($command->argument('order')) {
+//            $orderId = $command->argument('order');
+//            $order   = Order::findOrFail($orderId);
+//            $this->commandProcess($command, $order);
+//        } else {
+//            $count = 0;
+//            $command->info('Processing all orders in chunks of 1000...');
+//
+//            Order::chunk(1000, function ($orders) use ($command, &$count) {
+//                foreach ($orders as $order) {
+//                    $this->commandProcess($command, $order);
+//                    $count++;
+//                }
+//                $command->info("Processed $count orders so far...");
+//            });
+//
+//            $command->info("Completed processing all $count orders.");
+//        }
+//
+//
+//        return 0;
+//    }
+
+}

--- a/app/Actions/Ordering/Order/GetShippingZone.php
+++ b/app/Actions/Ordering/Order/GetShippingZone.php
@@ -9,9 +9,9 @@
 namespace App\Actions\Ordering\Order;
 
 use App\Enums\Ordering\ShippingZoneSchema\ShippingZoneSchemaStateEnum;
+use App\Models\Helpers\Address;
 use App\Models\Ordering\Order;
 use App\Models\Ordering\ShippingZone;
-use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Lorisleiva\Actions\Concerns\AsAction;
 
@@ -36,24 +36,8 @@ class GetShippingZone
             $territories = $shippingZone->territories;
 
             foreach ($territories as $territory) {
-                if ($order->deliveryAddress->country_code == Arr::get($territory, 'country_code')) {
-                    if (Arr::has($territory, 'included_postal_codes')) {
-                        if (preg_match(
-                            Arr::get($territory, 'included_postal_codes'),
-                            $order->deliveryAddress->postal_code,
-                        )) {
-                            return $shippingZone;
-                        }
-                    } elseif (Arr::has($territory, 'excluded_postal_codes')) {
-                        if (!preg_match(
-                            Arr::get($territory, 'excluded_postal_codes'),
-                            $order->deliveryAddress->postal_code,
-                        )) {
-                            return $shippingZone;
-                        }
-                    } else {
-                        return $shippingZone;
-                    }
+                if ($this->getShippingZoneFromTerritory($shippingZone, $order->deliveryAddress, $territory)) {
+                    return $shippingZone;
                 }
             }
         }
@@ -61,6 +45,37 @@ class GetShippingZone
 
         return null;
     }
+
+
+    private function getShippingZoneFromTerritory(ShippingZone $shippingZone, Address $address, array $territory): ?ShippingZone
+    {
+        if ($address->country_code == Arr::get($territory, 'country_code')) {
+            if (Arr::has($territory, 'included_postal_codes')) {
+                if ($this->postCodeMatch($address->postal_code, $territory['included_postal_codes'])) {
+                    return $shippingZone;
+                }
+            } elseif (Arr::has($territory, 'excluded_postal_codes')) {
+                if ($this->postCodeMatch($address->postal_code, $territory['excluded_postal_codes'])) {
+                    return $shippingZone;
+                }
+            } else {
+                return $shippingZone;
+            }
+        }
+
+        return null;
+    }
+
+
+    private function postCodeMatch(string $postalCode, string $pattern): bool
+    {
+        if (preg_match($pattern, $postalCode)) {
+            return true;
+        }
+
+        return false;
+    }
+
 
     private function getShippingZoneSchema(Order $order, $isDiscounted)
     {
@@ -76,43 +91,42 @@ class GetShippingZone
     }
 
 
-    public string $commandSignature = 'order:get-shipping-zone {order? : The ID of the order}';
-
-
-    public function commandProcess(Command $command, Order $order): void
-    {
-        $shippingZone = $this->handle($order);
-
-        if ($shippingZone) {
-            $command->info('Shipping zone found: '.$shippingZone->name.' ('.$shippingZone->slug.') ['.$shippingZone->id.']');
-        } else {
-            $command->info('No shipping zone found for the order.');
-        }
-    }
-
-    public function asCommand(Command $command): int
-    {
-        if ($command->argument('order')) {
-            $orderId = $command->argument('order');
-            $order   = Order::findOrFail($orderId);
-            $this->commandProcess($command, $order);
-        } else {
-            $count = 0;
-            $command->info('Processing all orders in chunks of 1000...');
-
-            Order::chunk(1000, function ($orders) use ($command, &$count) {
-                foreach ($orders as $order) {
-                    $this->commandProcess($command, $order);
-                    $count++;
-                }
-                $command->info("Processed $count orders so far...");
-            });
-
-            $command->info("Completed processing all $count orders.");
-        }
-
-
-        return 0;
-    }
+    //    public string $commandSignature = 'order:get-shipping-zone {order? : The ID of the order}';
+    //
+    //    public function commandProcess(Command $command, Order $order): void
+    //    {
+    //        $shippingZone = $this->handle($order);
+    //
+    //        if ($shippingZone) {
+    //            $command->info('Shipping zone found: '.$shippingZone->name.' ('.$shippingZone->slug.') ['.$shippingZone->id.']');
+    //        } else {
+    //            $command->info('No shipping zone found for the order.');
+    //        }
+    //    }
+    //
+    //    public function asCommand(Command $command): int
+    //    {
+    //        if ($command->argument('order')) {
+    //            $orderId = $command->argument('order');
+    //            $order   = Order::findOrFail($orderId);
+    //            $this->commandProcess($command, $order);
+    //        } else {
+    //            $count = 0;
+    //            $command->info('Processing all orders in chunks of 1000...');
+    //
+    //            Order::chunk(1000, function ($orders) use ($command, &$count) {
+    //                foreach ($orders as $order) {
+    //                    $this->commandProcess($command, $order);
+    //                    $count++;
+    //                }
+    //                $command->info("Processed $count orders so far...");
+    //            });
+    //
+    //            $command->info("Completed processing all $count orders.");
+    //        }
+    //
+    //
+    //        return 0;
+    //    }
 
 }

--- a/app/Actions/Ordering/Order/GetShippingZone.php
+++ b/app/Actions/Ordering/Order/GetShippingZone.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Wed, 02 Apr 2025 12:54:30 Malaysia Time, Kuala Lumpur, Malaysia
+ * Copyright (c) 2025, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\Ordering\Order;
+
+use App\Enums\Ordering\ShippingZoneSchema\ShippingZoneSchemaStateEnum;
+use App\Models\Ordering\Order;
+use App\Models\Ordering\ShippingZone;
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class GetShippingZone
+{
+    use AsAction;
+
+    public function handle(Order $order, $discount = false): ?ShippingZone
+    {
+        if ($order->collection_address_id) {
+            return null;
+        }
+
+        $shippingZoneSchema = $this->getShippingZoneSchema($order, $discount);
+
+        $shippingZones = $shippingZoneSchema->shippingZones()
+            ->where('status', true)
+            ->orderby('position', 'desc')
+            ->get();
+
+        foreach ($shippingZones as $shippingZone) {
+            $territories = $shippingZone->territories;
+
+            foreach ($territories as $territory) {
+                if ($order->deliveryAddress->country_code == Arr::get($territory, 'country_code')) {
+                    if (Arr::has($territory, 'included_postal_codes')) {
+                        if (preg_match(
+                            Arr::get($territory, 'included_postal_codes'),
+                            $order->deliveryAddress->postal_code,
+                        )) {
+                            return $shippingZone;
+                        }
+                    } elseif (Arr::has($territory, 'excluded_postal_codes')) {
+                        if (!preg_match(
+                            Arr::get($territory, 'excluded_postal_codes'),
+                            $order->deliveryAddress->postal_code,
+                        )) {
+                            return $shippingZone;
+                        }
+                    } else {
+                        return $shippingZone;
+                    }
+                }
+            }
+        }
+
+
+        return null;
+    }
+
+    private function getShippingZoneSchema(Order $order, $isDiscounted)
+    {
+        $query = $order->shop->shippingZoneSchemas()
+            ->where('state', ShippingZoneSchemaStateEnum::LIVE);
+        if ($isDiscounted) {
+            $query->where('is_current_discount', true);
+        } else {
+            $query->where('is_current', true);
+        }
+
+        return $query->first();
+    }
+
+
+    public string $commandSignature = 'order:get-shipping-zone {order? : The ID of the order}';
+
+
+    public function commandProcess(Command $command, Order $order): void
+    {
+        $shippingZone = $this->handle($order);
+
+        if ($shippingZone) {
+            $command->info('Shipping zone found: '.$shippingZone->name.' ('.$shippingZone->slug.') ['.$shippingZone->id.']');
+        } else {
+            $command->info('No shipping zone found for the order.');
+        }
+    }
+
+    public function asCommand(Command $command): int
+    {
+        if ($command->argument('order')) {
+            $orderId = $command->argument('order');
+            $order   = Order::findOrFail($orderId);
+            $this->commandProcess($command, $order);
+        } else {
+            $count = 0;
+            $command->info('Processing all orders in chunks of 1000...');
+
+            Order::chunk(1000, function ($orders) use ($command, &$count) {
+                foreach ($orders as $order) {
+                    $this->commandProcess($command, $order);
+                    $count++;
+                }
+                $command->info("Processed $count orders so far...");
+            });
+
+            $command->info("Completed processing all $count orders.");
+        }
+
+
+        return 0;
+    }
+
+}

--- a/app/Actions/Ordering/ShippingZone/StoreShippingZone.php
+++ b/app/Actions/Ordering/ShippingZone/StoreShippingZone.php
@@ -38,7 +38,7 @@ class StoreShippingZone extends OrgAction
 
         return DB::transaction(function () use ($shippingZoneSchema, $modelData) {
             /** @var $shippingZone ShippingZone */
-            $shippingZone = $shippingZoneSchema->shippingZone()->create($modelData);
+            $shippingZone = $shippingZoneSchema->shippingZones()->create($modelData);
             $shippingZone->stats()->create();
             $shippingZone->refresh();
 

--- a/app/Models/Ordering/ShippingZone.php
+++ b/app/Models/Ordering/ShippingZone.php
@@ -76,11 +76,11 @@ class ShippingZone extends Model implements Auditable
     use HasHistory;
 
     protected $casts = [
-        'territories' => 'array',
-        'price'       => 'array',
-        'status'      => 'boolean',
-        'fetched_at'         => 'datetime',
-        'last_fetched_at'    => 'datetime',
+        'territories'     => 'array',
+        'price'           => 'array',
+        'status'          => 'boolean',
+        'fetched_at'      => 'datetime',
+        'last_fetched_at' => 'datetime',
     ];
 
     protected $attributes = [

--- a/app/Models/Ordering/ShippingZoneSchema.php
+++ b/app/Models/Ordering/ShippingZoneSchema.php
@@ -107,7 +107,7 @@ class ShippingZoneSchema extends Model implements Auditable
         return 'slug';
     }
 
-    public function shippingZone(): HasMany
+    public function shippingZones(): HasMany
     {
         return $this->hasMany(ShippingZone::class);
     }


### PR DESCRIPTION
 
 
 **PR Summary by Typo**
------------

**Overview**
This PR introduces functionality to calculate shipping amounts for orders based on shipping zones and territories.  It adds two new actions, `GetShippingAmount` and `GetShippingZone`, and modifies existing models and actions to support the new logic.

**Key Changes**
- Added `GetShippingAmount` action to calculate the shipping amount based on the order's `goods_amount` or `estimated_weight` and the shipping zone's pricing tiers.
- Added `GetShippingZone` action to determine the applicable shipping zone based on the order's delivery address and the shop's shipping zone schema.
- Updated `ShippingZoneSchema` model to define a `shippingZones` relationship.
- Updated `ShippingZone` model to adjust attribute casting.
- Modified `StoreShippingZone` action to use the new `shippingZones` relationship.

**Recommendations**
Not deployment ready.  Error handling should be improved in the `GetShippingAmount` and `GetShippingZone` actions to gracefully handle cases where no shipping zone is found or pricing data is invalid.  Consider adding logging to track these scenarios and aid in debugging.  Additionally, input validation should be added to ensure data integrity.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>