### PR TITLE
1582 order bug fixes

### DIFF
--- a/app/Actions/Ordering/Order/UI/ShowOrder.php
+++ b/app/Actions/Ordering/Order/UI/ShowOrder.php
@@ -427,7 +427,7 @@ class ShowOrder extends OrgAction
                     ],
                     'pinned_address_id'              => $order->customer->delivery_address_id,
                     'home_address_id'                => $order->customer->address_id,
-                    'current_selected_address_id'    => $order->customer->delivery_address_id,
+                    'current_selected_address_id'    => $order->delivery_address_id,
                     'selected_delivery_addresses_id' => $orderDeliveryAddressIds,
                     'routes_list'                    => [
                         'pinned_route'                   => [

--- a/app/Actions/Ordering/Order/UI/ShowOrder.php
+++ b/app/Actions/Ordering/Order/UI/ShowOrder.php
@@ -208,6 +208,20 @@ class ShowOrder extends OrgAction
                                 ]
                             ]
                         ] : [],
+                        [
+                            'type'    => 'button',
+                            'style'   => 'delete',
+                            'tooltip' => __('cancel'),
+                            'label'   => __('cancel'),
+                            'key'     => 'action',
+                            'route'   => [
+                                'method'     => 'patch',
+                                'name'       => 'grp.models.order.state.cancelled',
+                                'parameters' => [
+                                    'order' => $order->id
+                                ]
+                            ]
+                        ],
                 ],
                 OrderStateEnum::SUBMITTED => [
                     [
@@ -223,7 +237,21 @@ class ShowOrder extends OrgAction
                                 'order' => $order->id
                             ]
                         ]
-                    ]
+                    ],
+                    [
+                        'type'    => 'button',
+                        'style'   => 'delete',
+                        'tooltip' => __('cancel'),
+                        'label'   => __('cancel'),
+                        'key'     => 'action',
+                        'route'   => [
+                            'method'     => 'patch',
+                            'name'       => 'grp.models.order.state.cancelled',
+                            'parameters' => [
+                                'order' => $order->id
+                            ]
+                        ]
+                    ],
                 ],
                 OrderStateEnum::IN_WAREHOUSE => [
                     [

--- a/app/Actions/Ordering/Order/UpdateOrderStateToCancelled.php
+++ b/app/Actions/Ordering/Order/UpdateOrderStateToCancelled.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ * author Arya Permana - Kirin
+ * created on 07-04-2025-11h-49m
+ * github: https://github.com/KirinZero0
+ * copyright 2025
+*/
+
+namespace App\Actions\Ordering\Order;
+
+use App\Actions\OrgAction;
+use App\Actions\Traits\Authorisations\HasOrderingAuthorisation;
+use App\Actions\Traits\WithActionUpdate;
+use App\Enums\Ordering\Order\OrderStateEnum;
+use App\Enums\Ordering\Order\OrderStatusEnum;
+use App\Enums\Ordering\Transaction\TransactionStateEnum;
+use App\Enums\Ordering\Transaction\TransactionStatusEnum;
+use App\Models\Ordering\Order;
+use Illuminate\Validation\Validator;
+use Lorisleiva\Actions\ActionRequest;
+
+class UpdateOrderStateToCancelled extends OrgAction
+{
+    use WithActionUpdate;
+    use HasOrderHydrators;
+    use HasOrderingAuthorisation;
+
+
+    private Order $order;
+
+    public function __construct()
+    {
+        $this->authorisationType = 'update';
+    }
+
+    public function handle(Order $order): Order
+    {
+        $modelData = [
+            'state'  => OrderStateEnum::CANCELLED,
+        ];
+
+        $date = now();
+
+        if ($order->cancelled_at == null) {
+            data_set($modelData, 'cancelled_at', $date);
+        }
+
+        $transactions = $order->transactions()->where('state', TransactionStateEnum::CREATING)->get();
+        foreach ($transactions as $transaction) {
+            $transactionData = ['state' => TransactionStateEnum::CANCELLED];
+            data_set($transactionData, 'quantity_cancelled', $transaction->quantity_ordered);
+
+            $transaction->update($transactionData);
+        }
+
+        $this->update($order, $modelData);
+        $this->orderHydrators($order);
+
+        return $order;
+    }
+
+
+    public function afterValidator(Validator $validator): void
+    {
+        if ($this->order->state == OrderStateEnum::CANCELLED) {
+            $validator->errors()->add('state', __('Order has been cancelled'));
+        }
+    }
+
+    public function action(Order $order): Order
+    {
+        $this->asAction = true;
+        $this->scope    = $order->shop;
+        $this->order    = $order;
+        $this->initialisationFromShop($order->shop, []);
+
+        return $this->handle($order);
+    }
+
+    public function asController(Order $order, ActionRequest $request)
+    {
+        $this->order = $order;
+        $this->scope = $order->shop;
+        $this->initialisationFromShop($order->shop, $request);
+        return $this->handle($order);
+    }
+}

--- a/resources/js/Components/Tables/Grp/Helpers/TableProductList.vue
+++ b/resources/js/Components/Tables/Grp/Helpers/TableProductList.vue
@@ -118,7 +118,8 @@ const fetchProductList = async (url?: string) => {
     const data = response.data;
 
     if (url && optionsLinks.value?.next) {
-      products.value = [...products.value, ...data.data];
+      // products.value = [...products.value, ...data.data];
+      products.value = data.data;
     } else {
       resetProducts();
       products.value = data.data;
@@ -131,13 +132,13 @@ const fetchProductList = async (url?: string) => {
     if (!addedProductIds.value) {
       addedProductIds.value = new Set();
     }
-    data.data.forEach((product: any) => {
+   /*  data.data.forEach((product: any) => {
       if (product.purchase_order_id) {
         addedProductIds.value.add(product.purchase_order_id);
       }
-    });
+    }); */
 
-    emits("optionsList", products.value);
+    /* emits("optionsList", products.value); */
   } catch (error) {
     console.error("Error fetching product list:", error);
   } finally {
@@ -190,13 +191,14 @@ const onSubmitAddProducts = async (data: any, slotProps: any) => {
           .post(
             route(data.route?.name || "#", {
               ...data.route?.parameters,
-              historicSupplierProduct: slotProps.data.historic_id,
+              historicAsset: slotProps.data.historic_id,
               orgStock: slotProps.data.org_stock_id,
             })
           );
 
         // Refresh list and update addedProductIds
-        await fetchProductList();
+        /* await fetchProductList(); */
+        
         addedProductIds.value.add(productId);
         iconStates.value[productId] = {
           increment: "fal fa-cloud",

--- a/resources/js/Components/Utils/ModalProductList.vue
+++ b/resources/js/Components/Utils/ModalProductList.vue
@@ -132,7 +132,7 @@ const fetchProductList = async (url?: string) => {
 		const data = response.data
 
 		if (url && optionsLinks.value?.next) {
-			products.value = [...products.value, ...data.data]
+			products.value = data.data
 		} else {
 			resetProducts()
 			products.value = data.data

--- a/resources/js/Pages/Grp/Org/Ordering/Order.vue
+++ b/resources/js/Pages/Grp/Org/Ordering/Order.vue
@@ -548,8 +548,12 @@ const openModal = (action :any) => {
                 <dt class="flex-none">
                     <FontAwesomeIcon icon='fal fa-shipping-fast' class='text-gray-400' fixed-width aria-hidden='true' />
                 </dt>
-                <dd class="w-full text-gray-500 text-xs relative px-2.5 py-2 ring-1 ring-gray-300 rounded bg-gray-50"
-                    v-html="box_stats?.customer.addresses.delivery.formatted_address">
+                <dd class="w-full text-gray-500 text-xs relative px-2.5 py-2 ring-1 ring-gray-300 rounded bg-gray-50">
+                    <span v-html="box_stats?.customer.addresses.delivery.formatted_address"></span>
+                    <div @click="() => isModalAddress = true"
+                        class="whitespace-nowrap select-none text-gray-500 hover:text-blue-600 underline cursor-pointer">
+                        <span>{{ trans('Edit') }}</span>
+                    </div>
                 </dd>
             </div>
 

--- a/routes/grp/web/models/ordering/order.php
+++ b/routes/grp/web/models/ordering/order.php
@@ -28,6 +28,7 @@ use App\Actions\Helpers\Media\DetachAttachmentFromModel;
 use App\Actions\Ordering\Order\PayOrder;
 use App\Actions\Ordering\Order\SendOrderToWarehouse;
 use App\Actions\Ordering\Order\UpdateOrder;
+use App\Actions\Ordering\Order\UpdateOrderStateToCancelled;
 use App\Actions\Ordering\Order\UpdateOrderStateToSubmitted;
 use App\Actions\Ordering\Order\UpdateStateToCreatingOrder;
 use App\Actions\Ordering\Order\UpdateStateToDispatchedOrder;
@@ -58,6 +59,7 @@ Route::name('order.')->prefix('order/{order:id}')->group(function () {
     Route::name('state.')->prefix('state')->group(function () {
         Route::patch('creating', UpdateStateToCreatingOrder::class)->name('creating');
         Route::patch('submitted', UpdateOrderStateToSubmitted::class)->name('submitted');
+        Route::patch('cancelled', UpdateOrderStateToCancelled::class)->name('cancelled');
         Route::patch('in-warehouse', SendOrderToWarehouse::class)->name('in-warehouse');
         Route::patch('handling', UpdateStateToHandlingOrder::class)->name('handling');
         Route::patch('packed', UpdateStateToPackedOrder::class)->name('packed');


### PR DESCRIPTION
 
 
 
 
 **PR Summary by Typo**
------------

**Overview**
This PR introduces a new feature to cancel orders and fixes bugs related to order processing and product lists.  It adds a "Cancel" button to the order details page and updates the backend to handle order cancellations.  Additionally, it corrects the product list fetching logic to prevent duplication and ensures the correct product IDs are used when adding products to an order.

**Key Changes**
- Added a new action `UpdateOrderStateToCancelled` and corresponding route to handle order cancellations.
- Implemented a "Cancel" button in the order details view (`Order.vue`).
- Fixed product list fetching in `TableProductList.vue` and `ModalProductList.vue` to prevent data duplication.
- Corrected the product ID used when adding products to an order in `TableProductList.vue`.
- Updated the order details view to display the correct delivery address and added an "Edit" button.

**Recommendations**
Not deployment ready.  While the changes address the described issues, the PR lacks sufficient error handling within the new cancellation action.  Implement robust error handling, including logging and user-facing messages, to ensure production stability.  Additionally, consider adding input validation to prevent unintended cancellations.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>