### PR TITLE
1591 mobile setting workshop and imporve mobile view for iris

### DIFF
--- a/resources/js/Components/CMS/Fields/Background.vue
+++ b/resources/js/Components/CMS/Fields/Background.vue
@@ -8,6 +8,10 @@ const props = defineProps<{
     uploadRoutes?: routeType
 }>()
 
+const emits = defineEmits<{
+    (e: 'update:modelValue', value: string | number): void
+}>()
+
 const defaultModel = {
     type: 'color',
     color: 'rgba(255, 255, 255, 1)',
@@ -26,7 +30,7 @@ const localModel = computed({
 
 <template>
     <div>
-        <BackgroundProperty v-model="localModel" :uploadImageRoute="uploadRoutes" />
+        <BackgroundProperty :modelValue="localModel" :uploadImageRoute="uploadRoutes" @update:modelValue="(val)=>emits('update:modelValue',val)" />
     </div>
 </template>
 

--- a/resources/js/Components/CMS/Fields/Border.vue
+++ b/resources/js/Components/CMS/Fields/Border.vue
@@ -8,6 +8,11 @@ const model = defineModel<typeof localModel>({
     required: true,
 })
 
+const emits = defineEmits<{
+    (e: 'update:modelValue', value: string | number): void
+}>()
+
+
 // Create a local copy of the model for internal use
 const localModel = {
     top: { value: null },
@@ -76,7 +81,9 @@ onMounted(async () => {
 <template>
     <div >
         <BorderProperty
-            v-model="model"
+            :modelValue="model" @update:model-value="(value) => {
+                emits('update:modelValue', value)
+            }"
         />
     </div>
 </template>

--- a/resources/js/Components/CMS/Fields/Dimension.vue
+++ b/resources/js/Components/CMS/Fields/Dimension.vue
@@ -8,6 +8,10 @@ const defaultModel = {
     width: { value: null, unit: '%' },
 }
 
+const emits = defineEmits<{
+    (e: 'update:modelValue', value: string | number): void
+}>()
+
 // Menggunakan defineModel untuk dua arah binding
 const model = defineModel<typeof defaultModel>({
     default: () => ({ height: { value: null, unit: 'px' }, width: { value: null, unit: '%' } })
@@ -30,7 +34,7 @@ onMounted(() => {
 
 <template>
     <div>
-        <DimensionProperty v-model="model" />
+        <DimensionProperty :model-value="model"  @update:model-value="val => emits('update:modelValue',val)"/>
     </div>
 </template>
 

--- a/resources/js/Components/CMS/Fields/InputNumberCss.vue
+++ b/resources/js/Components/CMS/Fields/InputNumberCss.vue
@@ -2,14 +2,16 @@
 import { computed } from 'vue'
 import InputNumberCssProperty from '@/Components/Workshop/Properties/InputNumberCssProperty.vue'
 
+
 // Define the expected shape
 type CssProperty = {
   value: number | null
   unit: string
 }
 
-// Default structure
-const defaultModel: CssProperty = { value: null, unit: 'px' }
+const emits = defineEmits<{
+    (e: 'update:modelValue', value: string | number): void
+}>()
 
 // Accepting model from parent — might be undefined or partial
 const rawModel = defineModel<Partial<CssProperty>>({
@@ -32,6 +34,6 @@ const normalizedModel = computed<CssProperty>({
 
 <template>
   <div>
-    <InputNumberCssProperty v-model="normalizedModel" />
+    <InputNumberCssProperty :modelValue="normalizedModel" @update:model-value="(val)=> emits('update:modelValue',val)" />
   </div>
 </template>

--- a/resources/js/Components/CMS/Fields/Margin.vue
+++ b/resources/js/Components/CMS/Fields/Margin.vue
@@ -35,9 +35,8 @@ onMounted(() => {
 
 
 <template>
-    <div class="pb-3">
-        <PaddingMarginProperty :modelValue="model" :scope="trans('Margin')" />
-    </div>
+        <PaddingMarginProperty v-model="model" :scope="trans('Margin')" />
 </template>
 
-<style scoped></style>
+<style scoped>
+</style>

--- a/resources/js/Components/CMS/Fields/Margin.vue
+++ b/resources/js/Components/CMS/Fields/Margin.vue
@@ -3,6 +3,7 @@ import { onMounted, inject } from 'vue'
 import PaddingMarginProperty from '@/Components/Workshop/Properties/PaddingMarginProperty.vue'
 import { trans } from 'laravel-vue-i18n'
 import { cloneDeep, defaultsDeep } from 'lodash-es'
+import { isPlainObject } from 'lodash-es'
 
 const emit = defineEmits(['update:modelValue'])
 
@@ -25,18 +26,21 @@ const localModel = {
 }
 
 onMounted(() => {
-  if (!model.value || Object.keys(model.value).length === 0) {
-    model.value = cloneDeep(localModel)
-  } else {
-    model.value = defaultsDeep(cloneDeep(model.value), cloneDeep(localModel))
+  if (!isPlainObject(model.value)) return
+
+  for (const key in localModel) {
+    if (!(key in model.value)) {
+      // @ts-ignore
+      model.value[key] = cloneDeep(localModel[key])
+    }
   }
 })
 </script>
 
 
 <template>
-        <PaddingMarginProperty v-model="model" :scope="trans('Margin')" />
+  <PaddingMarginProperty :modelValue="model" :scope="trans('Margin')"
+    @update:modelValue="val => emit('update:modelValue', val)" />
 </template>
 
-<style scoped>
-</style>
+<style scoped></style>

--- a/resources/js/Components/CMS/Fields/Padding.vue
+++ b/resources/js/Components/CMS/Fields/Padding.vue
@@ -3,6 +3,7 @@ import { onMounted, inject } from 'vue'
 import PaddingMarginProperty from '@/Components/Workshop/Properties/PaddingMarginProperty.vue'
 import { trans } from 'laravel-vue-i18n'
 import { cloneDeep, defaultsDeep } from 'lodash-es'
+import { isPlainObject } from 'lodash-es'
 
 const emit = defineEmits(['update:modelValue'])
 
@@ -24,17 +25,23 @@ const localModel = {
   bottom: { value: null }
 }
 
+
+
 onMounted(() => {
-  if (!model.value || Object.keys(model.value).length === 0) {
-    model.value = cloneDeep(localModel)
-  } else {
-    model.value = defaultsDeep(cloneDeep(model.value), cloneDeep(localModel))
+  if (!isPlainObject(model.value)) return
+
+  for (const key in localModel) {
+    if (!(key in model.value)) {
+      // @ts-ignore
+      model.value[key] = cloneDeep(localModel[key])
+    }
   }
 })
+
 </script>
 
 <template>
   <div class="pb-3">
-    <PaddingMarginProperty :modelValue="model" :scope="trans('Padding')" />
+    <PaddingMarginProperty :modelValue="model" :scope="trans('Padding')" @update:modelValue="(val) => emit('update:modelValue',val)"/>
   </div>
 </template>

--- a/resources/js/Components/CMS/Fields/Shadow.vue
+++ b/resources/js/Components/CMS/Fields/Shadow.vue
@@ -37,6 +37,6 @@ onMounted(() => {
 
 <template>
   <div class="pb-3">
-    <PaddingMarginProperty :modelValue="model" :scope="trans('Shadow')" />
+    <PaddingMarginProperty :modelValue="model" :scope="trans('Shadow')" @update:modelValue="(e)=>emit('update:modelValue',e)" />
   </div>
 </template>

--- a/resources/js/Components/CMS/Fields/Shadow.vue
+++ b/resources/js/Components/CMS/Fields/Shadow.vue
@@ -2,6 +2,7 @@
 import { onMounted, inject } from 'vue'
 import PaddingMarginProperty from '@/Components/Workshop/Properties/PaddingMarginProperty.vue'
 import { trans } from 'laravel-vue-i18n'
+import { cloneDeep, defaultsDeep } from 'lodash-es'
 
 // Define model structure
 const model = defineModel<{
@@ -14,30 +15,21 @@ const model = defineModel<{
 
 const emit = defineEmits(['update:modelValue'])
 
-// Injects
-const onSaveWorkshopFromId = inject('onSaveWorkshopFromId', (e?: number) => {
-  console.log('onSaveWorkshopFromId not provided')
-})
-const side_editor_block_id = inject('side_editor_block_id', () => {
-  console.log('side_editor_block_id not provided')
-})
 
-// Default value initializer
+// Default values
+const localModel = {
+  unit: "px",
+  top: { value: null },
+  left: { value: null },
+  right: { value: null },
+  bottom: { value: null }
+}
+
 onMounted(() => {
-  if (!model.value) {
-    model.value = {
-      unit: 'px',
-      top: { value: null },
-      left: { value: null },
-      right: { value: null },
-      bottom: { value: null }
-    }
+  if (!model.value || Object.keys(model.value).length === 0) {
+    model.value = cloneDeep(localModel)
   } else {
-    if (!model.value.unit) model.value.unit = 'px'
-    if (!model.value.top) model.value.top = { value: null }
-    if (!model.value.left) model.value.left = { value: null }
-    if (!model.value.right) model.value.right = { value: null }
-    if (!model.value.bottom) model.value.bottom = { value: null }
+    model.value = defaultsDeep(cloneDeep(model.value), cloneDeep(localModel))
   }
 })
 </script>
@@ -45,6 +37,6 @@ onMounted(() => {
 
 <template>
   <div class="pb-3">
-    <PaddingMarginProperty :modelValue="model || localModel" :scope="trans('Shadow')" />
+    <PaddingMarginProperty :modelValue="model" :scope="trans('Shadow')" />
   </div>
 </template>

--- a/resources/js/Components/CMS/Webpage/CTA/Blueprint.ts
+++ b/resources/js/Components/CMS/Webpage/CTA/Blueprint.ts
@@ -161,6 +161,7 @@ export default {
 			replaceForm: [
 				{
 					key: ["background"],
+					useIn : ["desktop", "tablet", "mobile"],
 					label :"Background",
 					type: "background",
 					
@@ -181,6 +182,7 @@ export default {
 				},
 				{
 					key: ["border"],
+					useIn : ["desktop", "tablet", "mobile"],
 					label : "Border",
 					type: "border",
 					

--- a/resources/js/Components/CMS/Webpage/CTA/Blueprint.ts
+++ b/resources/js/Components/CMS/Webpage/CTA/Blueprint.ts
@@ -9,6 +9,7 @@ export default {
 				{
 					key : ['source'],
 					label: "Image",
+					useIn : ["desktop", "tablet", "mobile"],
 					type: "upload_image",
 				},
 				{
@@ -19,6 +20,7 @@ export default {
 				{
 					key: ["properties", "object_fit"],
 					label: "Object Image",
+					useIn : ["desktop", "tablet", "mobile"],
 					type: "select",
 					props_data: {
 						placeholder: "Object",
@@ -159,35 +161,41 @@ export default {
 			replaceForm: [
 				{
 					key: ["background"],
+					useIn : ["desktop", "tablet", "mobile"],
 					label :"Background",
 					type: "background",
 					
 				},
 				{
 					key: ["padding"],
+					useIn : ["desktop", "tablet", "mobile"],
 					label : "Padding",
 					type: "padding",
 					
 				},
 				{
 					key: ["margin"],
+					useIn : ["desktop", "tablet", "mobile"],
 					label : "Margin",
 					type: "margin",
 					
 				},
 				{
 					key: ["border"],
+					useIn : ["desktop", "tablet", "mobile"],
 					label : "Border",
 					type: "border",
 					
 				},
 				{
                     key: ["shadow"],
+					useIn : ["desktop", "tablet", "mobile"],
                     label : "Shadow",
                     type: "shadow",
                 },
                 {
                     key: ["shadowColor"],
+					useIn : ["desktop", "tablet", "mobile"],
                     label : "Shadow Color",
                     type: "color",
                 },

--- a/resources/js/Components/CMS/Webpage/CTA/Blueprint.ts
+++ b/resources/js/Components/CMS/Webpage/CTA/Blueprint.ts
@@ -161,7 +161,6 @@ export default {
 			replaceForm: [
 				{
 					key: ["background"],
-					useIn : ["desktop", "tablet", "mobile"],
 					label :"Background",
 					type: "background",
 					
@@ -182,20 +181,17 @@ export default {
 				},
 				{
 					key: ["border"],
-					useIn : ["desktop", "tablet", "mobile"],
 					label : "Border",
 					type: "border",
 					
 				},
 				{
                     key: ["shadow"],
-					useIn : ["desktop", "tablet", "mobile"],
                     label : "Shadow",
                     type: "shadow",
                 },
                 {
                     key: ["shadowColor"],
-					useIn : ["desktop", "tablet", "mobile"],
                     label : "Shadow Color",
                     type: "color",
                 },

--- a/resources/js/Components/CMS/Webpage/CTA/CTAIris.vue
+++ b/resources/js/Components/CMS/Webpage/CTA/CTAIris.vue
@@ -18,14 +18,17 @@ library.add(faCube, faLink, faImage)
 const props = defineProps<{
 	fieldValue: FieldValue
 	webpageData?: any
-	blockData?: Object
+	blockData?: Object,
+	screenType: 'mobile' | 'tablet' | 'desktop'
 }>()
 
 
 </script>
 
 <template>
-	<div class="relative" :style="getStyles(fieldValue?.container?.properties)">
+	<!-- {{ fieldValue?.container?.properties }} -->
+	{{ getStyles(fieldValue?.container?.properties,screenType) }}
+	<div class="relative" :style="getStyles(fieldValue?.container?.properties,screenType)">
 		<div class="relative h-80 overflow-hidden md:absolute md:left-0 md:h-full md:w-1/3 lg:w-1/2">
 			<template v-if="fieldValue?.image?.source">
 				<Image :src="fieldValue?.image?.source" :imageCover="true" :alt="fieldValue?.image?.alt"

--- a/resources/js/Components/CMS/Webpage/CTA/CTAIris.vue
+++ b/resources/js/Components/CMS/Webpage/CTA/CTAIris.vue
@@ -27,7 +27,6 @@ const props = defineProps<{
 
 <template>
 	<!-- {{ fieldValue?.container?.properties }} -->
-	{{ getStyles(fieldValue?.container?.properties,screenType) }}
 	<div class="relative" :style="getStyles(fieldValue?.container?.properties,screenType)">
 		<div class="relative h-80 overflow-hidden md:absolute md:left-0 md:h-full md:w-1/3 lg:w-1/2">
 			<template v-if="fieldValue?.image?.source">

--- a/resources/js/Components/CMS/Webpage/CTA/CTAWorkshop.vue
+++ b/resources/js/Components/CMS/Webpage/CTA/CTAWorkshop.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
 	modelValue: any
 	webpageData?: any
 	blockData?: Object
+	screenType: "mobile" | "tablet" | "desktop"
 }>()
 
 const emits = defineEmits<{
@@ -22,7 +23,8 @@ const emits = defineEmits<{
 </script>
 
 <template>
-	<div class="relative" :style="getStyles(modelValue.container.properties)">
+		{{ getStyles(modelValue?.container?.properties,screenType) }}
+	<div class="relative" :style="getStyles(modelValue.container.properties,screenType)">
 		<div
 			@click="
 				() =>

--- a/resources/js/Components/CMS/Webpage/CTA/CTAWorkshop.vue
+++ b/resources/js/Components/CMS/Webpage/CTA/CTAWorkshop.vue
@@ -23,7 +23,6 @@ const emits = defineEmits<{
 </script>
 
 <template>
-		{{ getStyles(modelValue?.container?.properties,screenType) }}
 	<div class="relative" :style="getStyles(modelValue.container.properties,screenType)">
 		<div
 			@click="

--- a/resources/js/Components/ScreenView.vue
+++ b/resources/js/Components/ScreenView.vue
@@ -9,8 +9,10 @@ library.add(faDesktop, faMobileAndroidAlt, faTabletAndroidAlt)
 
 const props = withDefaults(defineProps<{
     currentView?: string
+    showList?:Array<string>
 }>(), {
-    currentView: 'desktop'
+    currentView: 'desktop',
+    showList: ['mobile', 'tablet', 'desktop']
 })
 
 defineEmits<{
@@ -25,7 +27,7 @@ const screenView = ref(props.currentView)
 
 <template>
     <div class="flex">
-        <div
+        <div v-if="showList.includes('mobile')"
             class="py-1 px-2 cursor-pointer"
             :class="[screenView == 'mobile' ? 'selected-bg' : 'unselected-bg']"
             @click="screenView = 'mobile', $emit('screenView', 'mobile')"
@@ -34,7 +36,7 @@ const screenView = ref(props.currentView)
             <FontAwesomeIcon icon='fal fa-mobile-android-alt' fixed-width aria-hidden='true' />
         </div>
 
-        <div
+        <div v-if="showList.includes('tablet')"
             class="py-1 px-2 cursor-pointer  md:block hidden"
             :class="[screenView == 'tablet' ? 'selected-bg' : 'unselected-bg']"
             @click="screenView = 'tablet', $emit('screenView', 'tablet')"
@@ -43,7 +45,7 @@ const screenView = ref(props.currentView)
             <FontAwesomeIcon icon='fal fa-tablet-android-alt' fixed-width aria-hidden='true' />
         </div>
 
-        <div
+        <div v-if="showList.includes('desktop')"
             class="py-1 px-2 cursor-pointer lg:block hidden"
             :class="[screenView == 'desktop' ? 'selected-bg' : 'unselected-bg']"
             @click="screenView = 'desktop', $emit('screenView', 'desktop')"

--- a/resources/js/Components/Workshop/Properties/BackgroundProperty.vue
+++ b/resources/js/Components/Workshop/Properties/BackgroundProperty.vue
@@ -28,6 +28,10 @@ const props = defineProps<{
     uploadImageRoute?: routeType
 }>()
 
+const emits = defineEmits<{
+    (e: 'update:modelValue', value: string | number): void
+}>()
+
 const model = defineModel<BackgroundProperty>({
     required: true,
     default : {
@@ -35,8 +39,8 @@ const model = defineModel<BackgroundProperty>({
     }
 })
 
-const onSaveWorkshopFromId: Function = inject('onSaveWorkshopFromId', (e?: number) => { console.log('onSaveWorkshopFromId not provided') })
-const side_editor_block_id = inject('side_editor_block_id', () => { console.log('side_editor_block_id not provided') })
+/* const onSaveWorkshopFromId: Function = inject('onSaveWorkshopFromId', (e?: number) => { console.log('onSaveWorkshopFromId not provided') })
+const side_editor_block_id = inject('side_editor_block_id', () => { console.log('side_editor_block_id not provided') }) */
 
 const isOpenGallery = ref(false)
 
@@ -46,7 +50,8 @@ const onSubmitSelectedImage = (images: ImageData[]) => {
     model.value.image = images[0]
     isOpenGallery.value = false
     model.value.type = 'image'
-    onSaveWorkshopFromId(side_editor_block_id, 'background property')
+    emits('update:modelValue', model.value)
+  /*   onSaveWorkshopFromId(side_editor_block_id, 'background property') */
 }
 
 
@@ -72,7 +77,7 @@ const onSubmitUpload = async (files: File[], galleryUploadRef : any) => {
         )
         
         model.value.image = aaa.data.data[0]
-        onSaveWorkshopFromId(side_editor_block_id, 'background image')
+        emits('update:modelValue', model.value)
 
         // Assuming you want to notify on success
         notify({
@@ -124,10 +129,10 @@ const onSubmitUpload = async (files: File[], galleryUploadRef : any) => {
                         <FontAwesomeIcon icon='fal fa-image' class='text-white' fixed-width aria-hidden='true' />
                     </div>
 
-                    <div v-else @click="() => (model.type = 'image', onSaveWorkshopFromId(side_editor_block_id, 'background type image'))" class="flex absolute inset-0 bg-gray-200/70 hover:bg-gray-100/40 items-center justify-center cursor-pointer" />
+                    <div v-else @click="() => (model.type = 'image',emits('update:modelValue', model))" class="flex absolute inset-0 bg-gray-200/70 hover:bg-gray-100/40 items-center justify-center cursor-pointer" />
                 </div>
             </div>
-            <PureRadio v-model="model.type" @update:modelValue="() => onSaveWorkshopFromId(side_editor_block_id, 'background type image')" :options="[{ name: 'image'}]" by="name" key="image1" />
+            <PureRadio v-model="model.type" @update:modelValue="() => emits('update:modelValue', model)" :options="[{ name: 'image'}]" by="name" key="image1" />
         </div>
         
         <!-- {{ model }} -->
@@ -140,7 +145,7 @@ const onSubmitUpload = async (files: File[], galleryUploadRef : any) => {
                     @changeColor="(newColor)=> {
                         model.color = `rgba(${newColor.rgba.r}, ${newColor.rgba.g}, ${newColor.rgba.b}, ${newColor.rgba.a})`,
                         model.type = 'color',
-                        onSaveWorkshopFromId(side_editor_block_id, 'background property')
+                        emits('update:modelValue', model)
                     }"
                     closeButton
                     v-tooltip="trans('Color background')"
@@ -159,7 +164,7 @@ const onSubmitUpload = async (files: File[], galleryUploadRef : any) => {
 
                     <template #before-main-picker>
                         <div class="flex items-center gap-2">
-                            <RadioButton size="small" v-model="model.color" @update:modelValue="() => onSaveWorkshopFromId(side_editor_block_id, 'background property')" inputId="bg-color-picker-1" name="bg-color-picker" value="var(--iris-color-primary)" />
+                            <RadioButton size="small" v-model="model.color" @update:modelValue="() => emits('update:modelValue', model)" inputId="bg-color-picker-1" name="bg-color-picker" value="var(--iris-color-primary)" />
                             <label class="cursor-pointer" for="bg-color-picker-1">{{ trans("Primary color") }} 
                                 <a  :href="route(route().params.shop ? 'grp.org.shops.show.web.websites.workshop' : 'grp.org.fulfilments.show.web.websites.workshop', {...route().params, tab: 'website_layout', section: 'theme_colors'})" as="a" target="_blank" class="text-xs text-blue-600">{{ trans("themes") }}</a>
                             </label>
@@ -168,7 +173,7 @@ const onSubmitUpload = async (files: File[], galleryUploadRef : any) => {
                         <div class="flex items-center gap-2">
                             <RadioButton size="small"
                                 :modelValue="!model.color?.includes('var') ? '#111111' : null"
-                                @update:modelValue="(e) => model.color.includes('var') ? (model.color = '#111111', onSaveWorkshopFromId(side_editor_block_id, 'background property')) : false"
+                                @update:modelValue="(e) => model.color.includes('var') ? (model.color = '#111111', emits('update:modelValue', model)) : false"
                                 inputId="bg-color-picker-3"
                                 name="bg-color-picker"
                                 value="#111111" />
@@ -177,12 +182,12 @@ const onSubmitUpload = async (files: File[], galleryUploadRef : any) => {
                     </template>
                 </ColorPicker>
                 
-                <div v-if="model.type !== 'color'" @click="() => (model.type = 'color', onSaveWorkshopFromId(side_editor_block_id, 'background type color'))" class="flex absolute inset-0 items-center justify-center cursor-pointer" />
+                <div v-if="model.type !== 'color'" @click="() => (model.type = 'color', emits('update:modelValue', model))" class="flex absolute inset-0 items-center justify-center cursor-pointer" />
 
             </div>
             <!-- <div v-else class="h-8 w-8 rounded-md border border-gray-300 shadow" :style="{background: model.color}" /> -->
 
-            <PureRadio v-model="model.type" @update:modelValue="() => onSaveWorkshopFromId(side_editor_block_id, 'background property')" :options="[{ name: 'color'}]" by="name" key="color2" />
+            <PureRadio v-model="model.type" @update:modelValue="() => emits('update:modelValue', model)" :options="[{ name: 'color'}]" by="name" key="color2" />
         </div>
     </div>
     

--- a/resources/js/Components/Workshop/Properties/BorderProperty.vue
+++ b/resources/js/Components/Workshop/Properties/BorderProperty.vue
@@ -48,8 +48,12 @@ const model = defineModel<Borderproperty>({
     required: true
 })
 
-const onSaveWorkshopFromId: Function = inject('onSaveWorkshopFromId', (e?: number) => { console.log('onSaveWorkshopFromId not provided') })
-const side_editor_block_id = inject('side_editor_block_id', () => { console.log('side_editor_block_id not provided') })  // Get the block id that use this property
+const emits = defineEmits<{
+    (e: 'update:modelValue', value: string | number): void
+}>()
+
+/* const onSaveWorkshopFromId: Function = inject('onSaveWorkshopFromId', (e?: number) => { console.log('onSaveWorkshopFromId not provided') })
+const side_editor_block_id = inject('side_editor_block_id', () => { console.log('side_editor_block_id not provided') })  */
 
 const isAllValueAreSame = (scope?: {}) => {
     if (!scope) return false
@@ -74,7 +78,8 @@ const changeBorderValueToSame = async (newVal: number) => {
         }
     }
 
-    onSaveWorkshopFromId(side_editor_block_id, 'border')
+    /* onSaveWorkshopFromId(side_editor_block_id, 'border') */
+    emits('update:modelValue', model.value)
 }
 
 // Section: Rounded same value
@@ -86,7 +91,7 @@ const changeRoundedValueToSame = (newVal: number) => {
             set(model.value, ['rounded', key, 'value'], newVal)
         }
     }
-    onSaveWorkshopFromId(side_editor_block_id, 'border')
+    emits('update:modelValue', model.value)
 }
 
 const iconRoundedCorner = `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 100 100">
@@ -109,7 +114,6 @@ const iconRoundedCorner = `<svg xmlns="http://www.w3.org/2000/svg" width="100%" 
 </script>
 
 <template>
-    <!-- <pre>{{ model }}</pre> -->
     <div class="flex flex-col pt-1 pb-3">
 
         <div class="pb-2">
@@ -117,7 +121,7 @@ const iconRoundedCorner = `<svg xmlns="http://www.w3.org/2000/svg" width="100%" 
                 <div class="text-xs">{{ trans('Color') }}</div>
                 <ColorPicker
                     :color="get(model, 'color', 'rgba(0, 0, 0, 1)')"
-                    @changeColor="(newColor)=> (set(model, 'color', `rgba(${newColor.rgba.r}, ${newColor.rgba.g}, ${newColor.rgba.b}, ${newColor.rgba.a}`), onSaveWorkshopFromId(side_editor_block_id, 'border'))"
+                    @changeColor="(newColor)=> (set(model, 'color', `rgba(${newColor.rgba.r}, ${newColor.rgba.g}, ${newColor.rgba.b}, ${newColor.rgba.a}`), emits('update:modelValue', model))"
                     closeButton
                 >
                     <template #button>
@@ -170,25 +174,25 @@ const iconRoundedCorner = `<svg xmlns="http://www.w3.org/2000/svg" width="100%" 
                         <div class="grid grid-cols-5 items-center w-full justify-center">
                             <FontAwesomeIcon icon='fad fa-border-top' v-tooltip="trans('Border top')" class='mx-auto' fixed-width aria-hidden='true' />
                             <div class="col-span-4">
-                                <PureInputNumber :modelValue="get(model, 'top.value', 0)" @update:modelValue="(e) => (set(model, 'top.value', e), onSaveWorkshopFromId(side_editor_block_id, 'border'))" class="" suffix="px" />
+                                <PureInputNumber :modelValue="get(model, 'top.value', 0)" @update:modelValue="(e) => (set(model, 'top.value', e), emits('update:modelValue', model))" class="" suffix="px" />
                             </div>
                         </div>
                         <div class="grid grid-cols-5 items-center w-full">
                             <FontAwesomeIcon icon='fad fa-border-bottom' v-tooltip="trans('Border bottom')" class='mx-auto' fixed-width aria-hidden='true' />
                             <div class="col-span-4">
-                                <PureInputNumber :modelValue="get(model, 'bottom.value', 0)" @update:modelValue="(e) => (set(model, 'bottom.value', e), onSaveWorkshopFromId(side_editor_block_id, 'border'))" class="" suffix="px" />
+                                <PureInputNumber :modelValue="get(model, 'bottom.value', 0)" @update:modelValue="(e) => (set(model, 'bottom.value', e), emits('update:modelValue', model))" class="" suffix="px" />
                             </div>
                         </div>
                         <div class="grid grid-cols-5 items-center w-full">
                             <FontAwesomeIcon icon='fad fa-border-left' v-tooltip="trans('Border left')" class='mx-auto' fixed-width aria-hidden='true' />
                             <div class="col-span-4">
-                                <PureInputNumber :modelValue="get(model, 'left.value', 0)" @update:modelValue="(e) => (set(model, 'left.value', e), onSaveWorkshopFromId(side_editor_block_id, 'border'))" class="" suffix="px" />
+                                <PureInputNumber :modelValue="get(model, 'left.value', 0)" @update:modelValue="(e) => (set(model, 'left.value', e), emits('update:modelValue', model))" class="" suffix="px" />
                             </div>
                         </div>
                         <div class="grid grid-cols-5 items-center w-full">
                             <FontAwesomeIcon icon='fad fa-border-right' v-tooltip="trans('Border right')" class='mx-auto' fixed-width aria-hidden='true' />
                             <div class="col-span-4">
-                                <PureInputNumber :modelValue="get(model, 'right.value', 0)" @update:modelValue="(e) => (set(model, 'right.value', e), onSaveWorkshopFromId(side_editor_block_id, 'border'))" class="" suffix="px" />
+                                <PureInputNumber :modelValue="get(model, 'right.value', 0)" @update:modelValue="(e) => (set(model, 'right.value', e), emits('update:modelValue', model))" class="" suffix="px" />
                             </div>
                         </div>
                     </div>
@@ -226,25 +230,25 @@ const iconRoundedCorner = `<svg xmlns="http://www.w3.org/2000/svg" width="100%" 
                         <div class="grid grid-cols-5 items-center w-full">
                             <div v-html="iconRoundedCorner" v-tooltip="trans('Corner top right')" class='h-5 w-5 mx-auto' />
                             <div class="col-span-4">
-                                <PureInputNumber :modelValue="get(model, 'rounded.topright.value', 0)" @update:modelValue="(e) => (set(model, 'rounded.topright.value', e), onSaveWorkshopFromId(side_editor_block_id, 'border'))" class="" suffix="px" />
+                                <PureInputNumber :modelValue="get(model, 'rounded.topright.value', 0)" @update:modelValue="(e) => (set(model, 'rounded.topright.value', e), emits('update:modelValue', model))" class="" suffix="px" />
                             </div>
                         </div>
                         <div class="grid grid-cols-5 items-center w-full">
                             <div v-html="iconRoundedCorner" v-tooltip="trans('Corner top left')" class='h-5 w-5 mx-auto -rotate-90' />
                             <div class="col-span-4">
-                                <PureInputNumber :modelValue="get(model, 'rounded.topleft.value', 0)" @update:modelValue="(e) => (set(model, 'rounded.topleft.value', e), onSaveWorkshopFromId(side_editor_block_id, 'border'))" class="" suffix="px" />
+                                <PureInputNumber :modelValue="get(model, 'rounded.topleft.value', 0)" @update:modelValue="(e) => (set(model, 'rounded.topleft.value', e), emits('update:modelValue', model))" class="" suffix="px" />
                             </div>
                         </div>
                         <div class="grid grid-cols-5 items-center w-full">
                             <div v-html="iconRoundedCorner" v-tooltip="trans('Corner bottom right')" class='h-5 w-5 mx-auto rotate-90' />
                             <div class="col-span-4">
-                                <PureInputNumber :modelValue="get(model, 'rounded.bottomright.value', 0)" @update:modelValue="(e) => (set(model, 'rounded.bottomright.value', e), onSaveWorkshopFromId(side_editor_block_id, 'border'))" class="" suffix="px" />
+                                <PureInputNumber :modelValue="get(model, 'rounded.bottomright.value', 0)" @update:modelValue="(e) => (set(model, 'rounded.bottomright.value', e), emits('update:modelValue', model))" class="" suffix="px" />
                             </div>
                         </div>
                         <div class="grid grid-cols-5 items-center w-full">
                             <div v-html="iconRoundedCorner" v-tooltip="trans('Corner bottom left')" class='h-5 w-5 mx-auto rotate-180' />
                             <div class="col-span-4">
-                                <PureInputNumber :modelValue="get(model, 'rounded.bottomleft.value', 0)" @update:modelValue="(e) => (set(model, 'rounded.bottomleft.value', e), onSaveWorkshopFromId(side_editor_block_id, 'border'))" class="" suffix="px" />
+                                <PureInputNumber :modelValue="get(model, 'rounded.bottomleft.value', 0)" @update:modelValue="(e) => (set(model, 'rounded.bottomleft.value', e), emits('update:modelValue', model))" class="" suffix="px" />
                             </div>
                         </div>
                     </div>

--- a/resources/js/Components/Workshop/Properties/ColorProperty.vue
+++ b/resources/js/Components/Workshop/Properties/ColorProperty.vue
@@ -4,7 +4,7 @@ import { trans } from 'laravel-vue-i18n'
 import ColorPicker from '@/Components/Utils/ColorPicker.vue'
 
 // Injected props
-const onSaveWorkshopFromId: Function = inject(
+/* const onSaveWorkshopFromId: Function = inject(
   'onSaveWorkshopFromId',
   (e?: number) => console.warn('onSaveWorkshopFromId not provided')
 )
@@ -12,7 +12,11 @@ const onSaveWorkshopFromId: Function = inject(
 const side_editor_block_id = inject('side_editor_block_id', () => {
   console.warn('side_editor_block_id not provided')
 })
+ */
 
+ const emits = defineEmits<{
+    (e: 'update:modelValue', value: string | number): void
+}>()
 // Model is a string, e.g., 'rgba(255,255,255,1)'
 const model = defineModel<string>({ required: true })
 
@@ -24,7 +28,8 @@ const handleColorChange = (newColor: any) => {
   const rgba = `rgba(${newColor.rgba.r}, ${newColor.rgba.g}, ${newColor.rgba.b}, ${newColor.rgba.a})`
   localColor.value = rgba
   model.value = rgba
-  onSaveWorkshopFromId(side_editor_block_id, 'ColorProperty')
+  /* onSaveWorkshopFromId(side_editor_block_id, 'ColorProperty') */
+  emits('update:modelValue', rgba)
 }
 </script>
 

--- a/resources/js/Components/Workshop/Properties/DimensionProperty.vue
+++ b/resources/js/Components/Workshop/Properties/DimensionProperty.vue
@@ -12,8 +12,12 @@ library.add(faBorderTop, faBorderLeft, faBorderBottom, faBorderRight, faBorderOu
 
 const model = defineModel()
 
-const onSaveWorkshopFromId: Function = inject('onSaveWorkshopFromId', (e?: number) => { console.log('onSaveWorkshopFromId not provided') })
-const side_editor_block_id = inject('side_editor_block_id', () => { console.log('side_editor_block_id not provided') })  // Get the block id that use this property
+/* const onSaveWorkshopFromId: Function = inject('onSaveWorkshopFromId', (e?: number) => { console.log('onSaveWorkshopFromId not provided') })
+const side_editor_block_id = inject('side_editor_block_id', () => { console.log('side_editor_block_id not provided') }) */
+
+const emits = defineEmits<{
+    (e: 'update:modelValue', value: string | number): void
+}>()
 
 </script>
 
@@ -34,10 +38,10 @@ const side_editor_block_id = inject('side_editor_block_id', () => { console.log(
                         leave-from-class="translate-y-0 opacity-100" leave-to-class="translate-y-1 opacity-0">
                         <PopoverPanel v-slot="{ close }"
                             class="bg-white shadow mt-3 absolute top-full right-0 z-10 w-32 transform rounded overflow-hidden">
-                            <div @click="() => { model.height.unit = 'px', onSaveWorkshopFromId(side_editor_block_id), close() }" class="px-4 py-1.5 cursor-pointer"
+                            <div @click="() => { model.height.unit = 'px', emits('update:modelValue',model), close() }" class="px-4 py-1.5 cursor-pointer"
                                 :class="model?.height.unit == 'px' ? 'bg-indigo-500 text-white' : 'hover:bg-indigo-100'">px
                             </div>
-                            <div @click="() => { model.height.unit = '%', onSaveWorkshopFromId(side_editor_block_id), close() }" class="px-4 py-1.5 cursor-pointer"
+                            <div @click="() => { model.height.unit = '%', emits('update:modelValue',model), close() }" class="px-4 py-1.5 cursor-pointer"
                                 :class="model?.height.unit == '%' ? 'bg-indigo-500 text-white' : 'hover:bg-indigo-100'">%</div>
                         </PopoverPanel>
                     </transition>
@@ -55,7 +59,7 @@ const side_editor_block_id = inject('side_editor_block_id', () => { console.log(
                                 <div class="col-span-4">
                                     <PureInputNumber
                                         :modelValue="get(model, 'height.value', 0)"
-                                        @update:modelValue="(newVal) => (set(model, 'height.value', newVal), onSaveWorkshopFromId(side_editor_block_id))"
+                                        @update:modelValue="(newVal) => (set(model, 'height.value', newVal), emits('update:modelValue',model))"
                                         class=""
                                         :suffix="model?.height.unit"
                                     />

--- a/resources/js/Components/Workshop/Properties/InputNumberCssProperty.vue
+++ b/resources/js/Components/Workshop/Properties/InputNumberCssProperty.vue
@@ -17,13 +17,19 @@ const model = defineModel<{ value: number; unit: string }>({
 })
 
 
-const onSaveWorkshopFromId: Function = inject('onSaveWorkshopFromId', (e?: number) => { console.log('onSaveWorkshopFromId not provided') })
-const side_editor_block_id = inject('side_editor_block_id', () => { console.log('side_editor_block_id not provided') })
+const emits = defineEmits<{
+    (e: 'update:modelValue', value: string | number): void
+}>()
+
+/* const onSaveWorkshopFromId: Function = inject('onSaveWorkshopFromId', (e?: number) => { console.log('onSaveWorkshopFromId not provided') })
+const side_editor_block_id = inject('side_editor_block_id', () => { console.log('side_editor_block_id not provided') }) */
 
 // Fungsi untuk memperbarui model
 const updateModel = (key: keyof typeof model.value, newValue: any) => {
   model.value = { ...model.value, [key]: newValue }
-  onSaveWorkshopFromId(side_editor_block_id)
+  /* onSaveWorkshopFromId(side_editor_block_id) */
+  console.log(model.value)
+  emits('update:modelValue', model.value)
 }
 </script>
 

--- a/resources/js/Components/Workshop/Properties/PaddingMarginProperty.vue
+++ b/resources/js/Components/Workshop/Properties/PaddingMarginProperty.vue
@@ -88,8 +88,8 @@ const changePaddingToSameValue = (newVal: number) => {
                         leave-to-class="translate-y-1 opacity-0"
                     >
                         <PopoverPanel v-slot="{ close }" class="bg-white shadow mt-3 absolute top-full right-0 z-10 w-32 transform rounded overflow-hidden">
-                            <div @click="() => {set(model, 'unit','px'), close()}" class="px-4 py-1.5 cursor-pointer" :class="model?.unit == 'px' ? 'bg-indigo-500 text-white' : 'hover:bg-indigo-100'">px</div>
-                            <div @click="() => {set(model, 'unit','%'), close()}" class="px-4 py-1.5 cursor-pointer" :class="model?.unit == '%' ? 'bg-indigo-500 text-white' : 'hover:bg-indigo-100'">%</div>
+                            <div @click="() => {set(model, 'unit','px'), close(), emits('update:modelValue', model)}" class="px-4 py-1.5 cursor-pointer" :class="model?.unit == 'px' ? 'bg-indigo-500 text-white' : 'hover:bg-indigo-100'">px</div>
+                            <div @click="() => {set(model, 'unit','%'), close(), emits('update:modelValue', model)}" class="px-4 py-1.5 cursor-pointer" :class="model?.unit == '%' ? 'bg-indigo-500 text-white' : 'hover:bg-indigo-100'">%</div>
                         </PopoverPanel>
                     </transition>
                 </Popover>
@@ -132,14 +132,14 @@ const changePaddingToSameValue = (newVal: number) => {
                             <div class="grid grid-cols-5 items-center">
                                 <FontAwesomeIcon icon='fad fa-border-top' v-tooltip="scope + ' ' + trans('top')" class='' fixed-width aria-hidden='true' />
                                 <div class="col-span-4">
-                                    <PureInputNumber :modelValue="get(model, 'top.value', 0)" @update:modelValue="(e) => (set(model, 'top.value', e))" class="" :suffix="model?.unit" />
+                                    <PureInputNumber :modelValue="get(model, 'top.value', 0)" @update:modelValue="(e) => (set(model, 'top.value', e), emits('update:modelValue', model))" class="" :suffix="model?.unit" />
                                 </div>
                             </div>
                             
                             <div class="grid grid-cols-5 items-center">
                                 <FontAwesomeIcon icon='fad fa-border-bottom' v-tooltip="scope + ' ' + trans('bottom')" class='' fixed-width aria-hidden='true' />
                                 <div class="col-span-4">
-                                    <PureInputNumber :modelValue="get(model, 'bottom.value', 0)" @update:modelValue="(e) => (set(model, 'bottom.value', e))" class="" :suffix="model?.unit" />
+                                    <PureInputNumber :modelValue="get(model, 'bottom.value', 0)" @update:modelValue="(e) => (set(model, 'bottom.value', e), emits('update:modelValue', model))" class="" :suffix="model?.unit" />
                                 </div>
                             </div>
                             
@@ -147,7 +147,7 @@ const changePaddingToSameValue = (newVal: number) => {
                                 <FontAwesomeIcon icon='fad fa-border-left' v-tooltip="scope + ' ' + trans('left')" class='' fixed-width aria-hidden='true' />
                                 <div class="col-span-4">
                                     <PureInputNumber
-                                        :modelValue="get(model, 'left.value', 0)" @update:modelValue="(e) => (set(model, 'left.value', e))"
+                                        :modelValue="get(model, 'left.value', 0)" @update:modelValue="(e) => (set(model, 'left.value', e),emits('update:modelValue', model))"
                                         class=""
                                         :suffix="model?.unit"
                                         :disabled="additionalData?.left?.disabled"
@@ -160,7 +160,7 @@ const changePaddingToSameValue = (newVal: number) => {
                                 <FontAwesomeIcon icon='fad fa-border-right' v-tooltip="scope + ' ' + trans('right')" class='' fixed-width aria-hidden='true' />
                                 <div class="col-span-4">
                                     <PureInputNumber
-                                        :modelValue="get(model, 'right.value', 0)" @update:modelValue="(e) => (set(model, 'right.value', e))"
+                                        :modelValue="get(model, 'right.value', 0)" @update:modelValue="(e) => (set(model, 'right.value', e),emits('update:modelValue', model))"
                                         class=""
                                         :suffix="model?.unit"
                                         :disabled="additionalData?.right?.disabled"

--- a/resources/js/Components/Workshop/Properties/PaddingMarginProperty.vue
+++ b/resources/js/Components/Workshop/Properties/PaddingMarginProperty.vue
@@ -36,8 +36,8 @@ const props = defineProps<{
 }>()
 
 
-const onSaveWorkshopFromId: Function = inject('onSaveWorkshopFromId', (e?: number) => { console.log('onSaveWorkshopFromId not provided') })
-const side_editor_block_id = inject('side_editor_block_id', () => { console.log('side_editor_block_id not provided') })  // Get the block id that use this property
+/* const onSaveWorkshopFromId: Function = inject('onSaveWorkshopFromId', (e?: number) => { console.log('onSaveWorkshopFromId not provided') })
+const side_editor_block_id = inject('side_editor_block_id', () => { console.log('side_editor_block_id not provided') }) */
 
 // Check if all padding values are the same
 const arePaddingValuesSame = (padding) => {
@@ -56,8 +56,10 @@ const changePaddingToSameValue = (newVal: number) => {
             model.value[key].value = newVal; // Set value to 99
         }
     }
-    onSaveWorkshopFromId(side_editor_block_id)
+   /*  onSaveWorkshopFromId(side_editor_block_id) */
+   /*  emits('update:modelValue', model.value) */
 }
+
 </script>
 
 <template>

--- a/resources/js/Components/Workshop/Properties/PaddingMarginProperty.vue
+++ b/resources/js/Components/Workshop/Properties/PaddingMarginProperty.vue
@@ -35,6 +35,9 @@ const props = defineProps<{
     }
 }>()
 
+const emits = defineEmits<{
+    (e: 'update:modelValue', value: string | number): void
+}>()
 
 /* const onSaveWorkshopFromId: Function = inject('onSaveWorkshopFromId', (e?: number) => { console.log('onSaveWorkshopFromId not provided') })
 const side_editor_block_id = inject('side_editor_block_id', () => { console.log('side_editor_block_id not provided') }) */
@@ -57,7 +60,7 @@ const changePaddingToSameValue = (newVal: number) => {
         }
     }
    /*  onSaveWorkshopFromId(side_editor_block_id) */
-   /*  emits('update:modelValue', model.value) */
+    emits('update:modelValue', model.value)
 }
 
 </script>
@@ -85,8 +88,8 @@ const changePaddingToSameValue = (newVal: number) => {
                         leave-to-class="translate-y-1 opacity-0"
                     >
                         <PopoverPanel v-slot="{ close }" class="bg-white shadow mt-3 absolute top-full right-0 z-10 w-32 transform rounded overflow-hidden">
-                            <div @click="() => {set(model, 'unit','px'), onSaveWorkshopFromId(side_editor_block_id), close()}" class="px-4 py-1.5 cursor-pointer" :class="model?.unit == 'px' ? 'bg-indigo-500 text-white' : 'hover:bg-indigo-100'">px</div>
-                            <div @click="() => {set(model, 'unit','%'), onSaveWorkshopFromId(side_editor_block_id), close()}" class="px-4 py-1.5 cursor-pointer" :class="model?.unit == '%' ? 'bg-indigo-500 text-white' : 'hover:bg-indigo-100'">%</div>
+                            <div @click="() => {set(model, 'unit','px'), close()}" class="px-4 py-1.5 cursor-pointer" :class="model?.unit == 'px' ? 'bg-indigo-500 text-white' : 'hover:bg-indigo-100'">px</div>
+                            <div @click="() => {set(model, 'unit','%'), close()}" class="px-4 py-1.5 cursor-pointer" :class="model?.unit == '%' ? 'bg-indigo-500 text-white' : 'hover:bg-indigo-100'">%</div>
                         </PopoverPanel>
                     </transition>
                 </Popover>
@@ -129,14 +132,14 @@ const changePaddingToSameValue = (newVal: number) => {
                             <div class="grid grid-cols-5 items-center">
                                 <FontAwesomeIcon icon='fad fa-border-top' v-tooltip="scope + ' ' + trans('top')" class='' fixed-width aria-hidden='true' />
                                 <div class="col-span-4">
-                                    <PureInputNumber :modelValue="get(model, 'top.value', 0)" @update:modelValue="(e) => (set(model, 'top.value', e), onSaveWorkshopFromId(side_editor_block_id))" class="" :suffix="model?.unit" />
+                                    <PureInputNumber :modelValue="get(model, 'top.value', 0)" @update:modelValue="(e) => (set(model, 'top.value', e))" class="" :suffix="model?.unit" />
                                 </div>
                             </div>
                             
                             <div class="grid grid-cols-5 items-center">
                                 <FontAwesomeIcon icon='fad fa-border-bottom' v-tooltip="scope + ' ' + trans('bottom')" class='' fixed-width aria-hidden='true' />
                                 <div class="col-span-4">
-                                    <PureInputNumber :modelValue="get(model, 'bottom.value', 0)" @update:modelValue="(e) => (set(model, 'bottom.value', e), onSaveWorkshopFromId(side_editor_block_id))" class="" :suffix="model?.unit" />
+                                    <PureInputNumber :modelValue="get(model, 'bottom.value', 0)" @update:modelValue="(e) => (set(model, 'bottom.value', e))" class="" :suffix="model?.unit" />
                                 </div>
                             </div>
                             
@@ -144,7 +147,7 @@ const changePaddingToSameValue = (newVal: number) => {
                                 <FontAwesomeIcon icon='fad fa-border-left' v-tooltip="scope + ' ' + trans('left')" class='' fixed-width aria-hidden='true' />
                                 <div class="col-span-4">
                                     <PureInputNumber
-                                        :modelValue="get(model, 'left.value', 0)" @update:modelValue="(e) => (set(model, 'left.value', e), onSaveWorkshopFromId(side_editor_block_id))"
+                                        :modelValue="get(model, 'left.value', 0)" @update:modelValue="(e) => (set(model, 'left.value', e))"
                                         class=""
                                         :suffix="model?.unit"
                                         :disabled="additionalData?.left?.disabled"
@@ -157,7 +160,7 @@ const changePaddingToSameValue = (newVal: number) => {
                                 <FontAwesomeIcon icon='fad fa-border-right' v-tooltip="scope + ' ' + trans('right')" class='' fixed-width aria-hidden='true' />
                                 <div class="col-span-4">
                                     <PureInputNumber
-                                        :modelValue="get(model, 'right.value', 0)" @update:modelValue="(e) => (set(model, 'right.value', e), onSaveWorkshopFromId(side_editor_block_id))"
+                                        :modelValue="get(model, 'right.value', 0)" @update:modelValue="(e) => (set(model, 'right.value', e))"
                                         class=""
                                         :suffix="model?.unit"
                                         :disabled="additionalData?.right?.disabled"

--- a/resources/js/Components/Workshop/Properties/TextProperty.vue
+++ b/resources/js/Components/Workshop/Properties/TextProperty.vue
@@ -17,9 +17,12 @@ interface TextProperty {
     fontFamily: String
 }
 
+const emits = defineEmits<{
+    (e: 'update:modelValue', value: string | number): void
+}>()
 
-const onSaveWorkshopFromId: Function = inject('onSaveWorkshopFromId', (e?: number) => { console.log('onSaveWorkshopFromId not provided') })
-const side_editor_block_id = inject('side_editor_block_id', () => { console.log('side_editor_block_id not provided') })  // Get the block id that use this property
+/* const onSaveWorkshopFromId: Function = inject('onSaveWorkshopFromId', (e?: number) => { console.log('onSaveWorkshopFromId not provided') })
+const side_editor_block_id = inject('side_editor_block_id', () => { console.log('side_editor_block_id not provided') }) */
 
 const model = defineModel<TextProperty>({
     required: true
@@ -46,7 +49,7 @@ const fontFamilies = [...useFontFamilyList];
                 <div class="text-xs">{{ trans('Text Color') }}</div>
                 <ColorPicker
                     :color="get(localModel, 'color', 'rgba(0, 0, 0, 1)')"
-                    @changeColor="(newColor)=> (set(localModel, 'color', `rgba(${newColor.rgba.r}, ${newColor.rgba.g}, ${newColor.rgba.b}, ${newColor.rgba.a}`), onSaveWorkshopFromId(side_editor_block_id, 'textPorperty'))"
+                    @changeColor="(newColor)=> (set(localModel, 'color', `rgba(${newColor.rgba.r}, ${newColor.rgba.g}, ${newColor.rgba.b}, ${newColor.rgba.a}`), emits('update:modelValue', model))"
                     closeButton
                 >
                     <template #button>
@@ -57,44 +60,12 @@ const fontFamilies = [...useFontFamilyList];
                         </div>
                     </template>
                 </ColorPicker>
-                <!-- <ColorPicker :color="localModel?.color"
-                    @changeColor="(newColor) => localModel.color = `rgba(${newColor.rgba.r}, ${newColor.rgba.g}, ${newColor.rgba.b}, ${newColor.rgba.a})`"
-                    closeButton
-                    :isEditable="!localModel?.color?.includes('var')"
-                >
-                    <template #button>
-                        <div v-bind="$attrs"
-                            class="overflow-hidden h-7 w-7 rounded border border-gray-300 cursor-pointer flex justify-center items-center"
-                            :style="{
-                                background: `${localModel.color}`
-                            }">
-                        </div>
-                    </template>
-
-                    <template #before-main-picker>
-                        <div class="flex items-center gap-2">
-                            <RadioButton size="small" v-model="localModel.color" inputId="bg-color-picker-1" name="bg-color-picker" value="var(--iris-color-primary)" />
-                            <label class="cursor-pointer" for="bg-color-picker-1">{{ trans("Primary color") }} 
-                                <a :href="route(route().params.shop ? 'grp.org.shops.show.web.websites.workshop' : 'grp.org.fulfilments.show.web.websites.workshop', {...route().params, tab: 'website_layout', section: 'theme_colors'})" as="a" target="_blank" class="text-xs text-blue-600">{{ trans("themes") }}</a></label>
-                        </div>
-                        
-                        <div class="flex items-center gap-2">
-                            <RadioButton size="small"
-                                :modelValue="!localModel.color?.includes('var') ? '#111111' : null"
-                                @update:modelValue="(e) => localModel.color?.includes('var') ? localModel.color = '#111111' : false"
-                                inputId="bg-color-picker-3"
-                                name="bg-color-picker"
-                                value="#111111" />
-                            <label class="cursor-pointer" for="bg-color-picker-3">{{ trans("Custom") }}</label>
-                        </div>
-                    </template>
-                </ColorPicker> -->
             </div>
 
             <div class="px-3 items-center">
                 <div class="text-xs mb-2">{{ trans('Font') }}</div>
                 <div class="col-span-4">
-                    <PureMultiselect v-model="localModel.fontFamily"  @update:modelValue="(e) => (set(localModel, 'fontFamily', e),onSaveWorkshopFromId(side_editor_block_id, 'textStyle'))" required :options="fontFamilies">
+                    <PureMultiselect v-model="localModel.fontFamily"  @update:modelValue="(e) => (set(localModel, 'fontFamily', e), emits('update:modelValue', model))" required :options="fontFamilies">
                         <template #option="{ option, isSelected, isPointed, search }">
                             <span :style="{
                                 fontFamily: option.value

--- a/resources/js/Components/Workshop/SideEditor/ChildFieldSideEditor.vue
+++ b/resources/js/Components/Workshop/SideEditor/ChildFieldSideEditor.vue
@@ -1,40 +1,44 @@
 <script setup lang="ts">
 import ParentFieldSideEditor from '@/Components/Workshop/SideEditor/ParentFieldSideEditor.vue'
-import { get } from 'lodash-es'
 import Accordion from 'primevue/accordion'
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { getFormValue } from '@/Composables/SideEditorHelper'
 
 import { routeType } from '@/types/route'
 const props = defineProps<{
-    blueprint: Array<{ key: string; label?: string; type?: string }>
+    blueprint: Array<{ key: string; label?: string; type?: string, replaceForm: Array<any> }>
     uploadImageRoute?: routeType
 }>()
 
+
+
 const modelValue = defineModel()
 const openPanel = ref(0)
-const emits = defineEmits<{
-    (e: 'update:modelValue', value: string | number): void
-}>()
-
 
 </script>
 
 <template>
-    <div v-for="(form, index) of blueprint.filter((item)=>item.type != 'hidden')" :key="form.key" class="">
+    <div v-for="(form, index) in blueprint.replaceForm.filter(f => f.type !== 'hidden')" :key="form.key">
         <Accordion v-if="form.name" class="w-full" v-model="openPanel">
-            <div v-if="form.type != 'hidden'">
-                <div v-if="get(form, 'label', '')" class="my-2 text-xs font-semibold">{{ get(form, 'label', '') }}</div>
-                <ParentFieldSideEditor :blueprint="form" :modelValue="modelValue" :uploadImageRoute="uploadImageRoute" 
-                    @update:modelValue="newValue => emits('update:modelValue', newValue)" :index="index" />
-            </div>
+            <template #default>
+                <div v-if="form.label" class="my-2 text-xs font-semibold">{{ form.label }}</div>
+                <ParentFieldSideEditor 
+                    :blueprint="form" 
+                    :modelValue="modelValue"
+                    :uploadImageRoute="uploadImageRoute" 
+                />
+            </template>
         </Accordion>
-        
-        <section v-else class="">
-            <ParentFieldSideEditor :blueprint="form" :modelValue="modelValue" :uploadImageRoute="uploadImageRoute" 
-                @update:modelValue="newValue => emits('update:modelValue', newValue)" :index="index" />
-        </section>
 
+        <div v-else>
+            <ParentFieldSideEditor 
+                :blueprint="form" 
+                :modelValue="modelValue"
+                :uploadImageRoute="uploadImageRoute" 
+            />
+        </div>
     </div>
+
 </template>
 
 

--- a/resources/js/Components/Workshop/SideEditor/ParentFieldSideEditor.vue
+++ b/resources/js/Components/Workshop/SideEditor/ParentFieldSideEditor.vue
@@ -1,127 +1,86 @@
 <script setup lang="ts">
-import { inject, ref } from 'vue'
-
+import { computed, inject } from 'vue'
 import AccordionPanel from 'primevue/accordionpanel'
 import AccordionHeader from 'primevue/accordionheader'
 import AccordionContent from 'primevue/accordioncontent'
-import ChildFieldSideEditor from '@/Components/Workshop/SideEditor/ChildFieldSideEditor.vue'
-import { trans } from 'laravel-vue-i18n'
-import { kebabCase } from 'lodash-es'
-import { v4 as uuidv4 } from 'uuid';
 
-import { getFormValue ,setFormValue, getComponent } from '@/Composables/SideEditorHelper'
-import { get } from 'lodash-es'
-import { routeType } from '@/types/route'
 import Icon from '@/Components/Icon.vue'
+import RenderFields from './RenderFields.vue'
+import ChildFieldSideEditor from '@/Components/Workshop/SideEditor/ChildFieldSideEditor.vue'
+import { getFormValue, setFormValue } from '@/Composables/SideEditorHelper'
+import { routeType } from '@/types/route'
 
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome"
-import { faInfoCircle, fa } from "@fal"
-import { library } from "@fortawesome/fontawesome-svg-core"
+// FontAwesome setup
+import { faInfoCircle } from '@fal'
+import { library } from '@fortawesome/fontawesome-svg-core'
 library.add(faInfoCircle)
 
 const props = defineProps<{
     blueprint: {
-        name : String,
-        type : String,
-        key : string | string[],
-        replaceForm : Array<any>
+        name: string
+        type: string
+        key: string | string[]
+        useIn: string[]
+        replaceForm: Array<any>
+        icon?: any
     }
-    uploadImageRoute?: routeType,
-    index:Number | string | string[]
+    uploadImageRoute?: routeType
+    index: number | string | string[]
 }>()
+
 const modelValue = defineModel()
+
+// Check if this blueprint should use a custom form editor
+const hasCustomForm = computed(() =>
+    Array.isArray(props.blueprint.replaceForm) && props.blueprint.replaceForm.length > 0
+)
 
 const onSaveWorkshopFromId: Function = inject('onSaveWorkshopFromId', (e?: number) => { console.log('onSaveWorkshopFromId not provided') })
 const side_editor_block_id = inject('side_editor_block_id', () => { console.log('side_editor_block_id not provided') })
 
 const onPropertyUpdate = (fieldKeys: string | string[], newVal: any) => {
+    console.log('onPropertyUpdate', fieldKeys, newVal)
     setFormValue(modelValue.value, fieldKeys, newVal)
     onSaveWorkshopFromId(side_editor_block_id, 'parentfieldsideeditor')
 }
 
+// Accordion key
+const accordionKey = computed(() =>
+    Array.isArray(props.blueprint.key) ? props.blueprint.key.join('-') : props.blueprint.key
+)
 </script>
 
 <template>
-    <AccordionPanel v-if="blueprint.name" :key="blueprint.name" :value="blueprint?.key?.join('-')">
+    <!-- Accordion mode -->
+    <AccordionPanel v-if="blueprint.name" :key="accordionKey" :value="accordionKey">
         <AccordionHeader>
-            <div>
-                <Icon v-if="blueprint?.icon" :data="blueprint.icon" />
-                {{ get(blueprint, 'name') }}
+            <div class="flex items-center gap-2">
+                <Icon v-if="blueprint.icon" :data="blueprint.icon" />
+                <span>{{ blueprint.name }}</span>
             </div>
         </AccordionHeader>
-        
-        <AccordionContent class="px-0">
-            <div class="">
-                <template v-if="blueprint.replaceForm">
-                    <ChildFieldSideEditor 
-                        :blueprint="blueprint.replaceForm"
-                        :modelValue="getFormValue(modelValue, blueprint.key)"
-                        :key="blueprint.key "
-                        :uploadImageRoute="uploadImageRoute" 
-                        @update:modelValue="newValue => onPropertyUpdate(blueprint.key, newValue)"
-                    />
-                </template>
 
-                <template v-else >
-                   <!--  <div class="my-2 text-xs font-semibold">{{ get(blueprint, 'label', '') }}</div> -->
-                    <div 
-                         class="w-full my-2 text-center py-1 font-semibold select-none text-sm "
-                         :class="blueprint.label && 'border-b border-gray-300 py-2'"
-                    >
-                         {{ trans(get(blueprint, 'label', '')) }}
-                    </div>
-                    <component 
-                        :is="getComponent(blueprint.type)" 
-                        :key="blueprint.key "
-                        :modelValue="getFormValue(modelValue, blueprint.key)"
-                        :uploadRoutes="uploadImageRoute" 
-                        v-bind="blueprint?.props_data" 
-                        @update:modelValue="newValue => onPropertyUpdate(blueprint.key, newValue)"
-                    />
-                </template>
-            </div>
+        <AccordionContent class="px-0">
+            <ChildFieldSideEditor v-if="hasCustomForm" :modelValue="getFormValue(modelValue, blueprint.key)"
+                :blueprint="blueprint" :uploadImageRoute="uploadImageRoute" />
+
+            <RenderFields v-else :modelValue="modelValue" :blueprint="blueprint"
+                :uploadImageRoute="uploadImageRoute"
+                @update:modelValue="onPropertyUpdate" />
         </AccordionContent>
     </AccordionPanel>
 
-    <div v-else class="bg-white mt-[0px] mb-2  pb-3">
-        <template v-if="blueprint.replaceForm">
-            <ChildFieldSideEditor
-                :blueprint="blueprint.replaceForm"
-                :modelValue="getFormValue(modelValue, blueprint.key)"
-                :key="blueprint.key "
-                :uploadImageRoute="uploadImageRoute" 
-                @update:modelValue="newValue => onPropertyUpdate(blueprint.key, newValue)"
-            />
-        </template>
+    <!-- Non-accordion mode -->
+    <div v-else class="bg-white mt-0 mb-2 pb-3">
+        <ChildFieldSideEditor v-if="hasCustomForm" :modelValue="getFormValue(modelValue, blueprint.key)"
+            :blueprint="blueprint" :uploadImageRoute="uploadImageRoute" />
 
-        <template v-else>
-           <!-- Section: Padding, Margin, Border -->
-            <div v-if="get(blueprint, 'label', '')" class="w-full my-2 text-start py-1 font-semibold select-none text-sm border-b border-gray-300">
-                {{ trans(get(blueprint, 'label', '')) }}
-                <VTooltip v-if="blueprint.information" class="inline w-fit" placements="right"> <!-- This placement don't work, later change to right -->
-                    <FontAwesomeIcon icon="fal fa-info-circle" class="text-gray-500 cursor-pointer" fixed-width aria-hidden="true" />
-                    <template #popper>
-                        <div class="min-w-20 w-fit max-w-64 text-xs">
-                            {{ blueprint.information }}
-                        </div>
-                    </template>
-                </VTooltip>
-            </div>
-            <component 
-                :is="getComponent(blueprint.type)" 
-                :key="blueprint.key "
-                :uploadRoutes="uploadImageRoute" 
-                v-bind="blueprint?.props_data" 
-                :modelValue="getFormValue(modelValue, blueprint.key)"
-                @update:modelValue="newValue => {
-                    onPropertyUpdate(blueprint.key, newValue)
-                }"
-            />
-        </template>
+
+        <RenderFields v-else :modelValue="modelValue" :blueprint="blueprint"
+            :uploadImageRoute="uploadImageRoute"
+            @update:modelValue="onPropertyUpdate" />
     </div>
-
 </template>
-
 
 <style lang="scss" scoped>
 .editor-content {
@@ -133,15 +92,14 @@ const onPropertyUpdate = (fieldKeys: string | string[], newVal: any) => {
     width: 100%;
 }
 
-.p-accordionpanel.p-accordionpanel-active > .p-accordionheader {
-    background-color: #433CC3 !important;
+.p-accordionpanel.p-accordionpanel-active>.p-accordionheader {
+    background-color: #433cc3 !important;
     border-radius: 0 !important;
     color: #fdfdfd !important;
 }
 
 .p-accordioncontent-content {
     padding: 10px !important;
-    background-color: #F9F9F9 !important;
+    background-color: #f9f9f9 !important;
 }
-
 </style>

--- a/resources/js/Components/Workshop/SideEditor/RenderFields.vue
+++ b/resources/js/Components/Workshop/SideEditor/RenderFields.vue
@@ -31,25 +31,20 @@ const emits = defineEmits<{
   (e: 'update:modelValue', key: string | string[], value: any): void
 }>()
 
-// Inject screen context (default desktop)
-const currentView = inject('currentView', ref('desktop'))
+const currentView = ref('desktop')
 
-// READ: Handle responsive-aware value with fallback to legacy (flat string)
 const valueForField = computed(() => {
   const rawVal = get(modelValue.value, props.blueprint.key)
   const useIn = props.blueprint.useIn
 
-  // Kalau useIn kosong atau bukan array, artinya tidak butuh responsive view
   if (!Array.isArray(useIn) || useIn.length === 0) {
     return rawVal
   }
 
-  // Kalau value bukan object (legacy atau input awal), langsung pakai saja
   if (!isPlainObject(rawVal)) {
     return rawVal
   }
 
-  // Kalau ada, ambil berdasarkan currentView → fallback ke desktop → kosong string
   return rawVal?.[currentView.value!] ?? rawVal?.desktop ?? rawVal
 })
 
@@ -79,8 +74,6 @@ const onPropertyUpdate = (newVal: any) => {
 
   emits('update:modelValue', rawKey, updatedValue)
 }
-
-
 
 
 </script>

--- a/resources/js/Components/Workshop/SideEditor/RenderFields.vue
+++ b/resources/js/Components/Workshop/SideEditor/RenderFields.vue
@@ -105,7 +105,7 @@ const onPropertyUpdate = (newVal: any) => {
     </div>
   </div>
 
-  <pre>{{get(modelValue, props.blueprint.key)}}</pre>
+  <!-- <pre>{{get(modelValue, props.blueprint.key)}}</pre> -->
   <component
     :is="getComponent(blueprint.type)"
     :uploadRoutes="uploadImageRoute"

--- a/resources/js/Components/Workshop/SideEditor/RenderFields.vue
+++ b/resources/js/Components/Workshop/SideEditor/RenderFields.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { ref, inject, computed } from 'vue'
+import { trans } from 'laravel-vue-i18n'
+import ScreenView from '@/Components/ScreenView.vue'
+
+import { get, isPlainObject } from 'lodash-es'
+import { routeType } from '@/types/route'
+import { getComponent } from '@/Composables/SideEditorHelper'
+
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome"
+import { faInfoCircle } from "@fal"
+import { library } from "@fortawesome/fontawesome-svg-core"
+library.add(faInfoCircle)
+
+const props = defineProps<{
+  blueprint: {
+    name: String,
+    type: String,
+    key: string | string[],
+    useIn: Array<string>,
+    label?: string,
+    information?: string,
+    props_data?: any
+  },
+  uploadImageRoute?: routeType,
+  index: Number | string | string[]
+}>()
+
+const modelValue = defineModel()
+const emits = defineEmits<{
+  (e: 'update:modelValue', key: string | string[], value: any): void
+}>()
+
+// Inject screen context (default desktop)
+const currentView = inject('currentView', ref('desktop'))
+
+// READ: Handle responsive-aware value with fallback to legacy (flat string)
+const valueForField = computed(() => {
+  const rawVal = get(modelValue.value, props.blueprint.key)
+  const useIn = props.blueprint.useIn
+
+  // Kalau useIn kosong atau bukan array, artinya tidak butuh responsive view
+  if (!Array.isArray(useIn) || useIn.length === 0) {
+    return rawVal
+  }
+
+  // Kalau value bukan object (legacy atau input awal), langsung pakai saja
+  if (!isPlainObject(rawVal)) {
+    return rawVal
+  }
+
+  // Kalau ada, ambil berdasarkan currentView → fallback ke desktop → kosong string
+  return rawVal?.[currentView.value!] ?? rawVal?.desktop ?? rawVal
+})
+
+const onPropertyUpdate = (newVal: any) => {
+  const rawKey = props.blueprint.key
+  const prevVal = get(modelValue.value, rawKey)
+  const useIn = props.blueprint.useIn
+
+  // ✅ Kalau useIn kosong → flat saja
+  if (!Array.isArray(useIn) || useIn.length === 0) {
+    emits('update:modelValue', rawKey, newVal)
+    return
+  }
+
+  // ✅ Kalau useIn ADA → data harus disimpan sebagai responsive format
+  // Contoh:
+  // - kalau newVal: "test" → simpan { desktop: "test" } (atau tergantung currentView)
+  // - kalau newVal: { object } → simpan langsung (anggap sudah benar)
+  const current = isPlainObject(prevVal) ? prevVal : {}
+
+  const updatedValue = Array.isArray(props.blueprint.useIn) && props.blueprint.useIn.length > 0
+  ? {
+      ...current,
+      [currentView.value]: newVal
+    }
+  : newVal
+
+  emits('update:modelValue', rawKey, updatedValue)
+}
+
+
+
+
+</script>
+
+<template>
+  <div v-if="blueprint.label" class="w-full my-2 py-1 border-b border-gray-300 text-sm select-none">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center font-semibold text-start">
+        {{ trans(blueprint.label) }}
+        <VTooltip v-if="blueprint.information" class="inline w-fit" placement="right">
+          <FontAwesomeIcon
+            icon="fal fa-info-circle"
+            class="ml-1 text-gray-500 cursor-pointer"
+            fixed-width
+            aria-hidden="true"
+          />
+          <template #popper>
+            <div class="min-w-20 w-fit max-w-64 text-xs">
+              {{ blueprint.information }}
+            </div>
+          </template>
+        </VTooltip>
+      </div>
+      <ScreenView
+        :show-list="blueprint.useIn || []"
+        :currentView="currentView"
+        @screen-view="e => currentView = e"
+      />
+    </div>
+  </div>
+
+  <pre>{{get(modelValue, props.blueprint.key)}}</pre>
+  <component
+    :is="getComponent(blueprint.type)"
+    :uploadRoutes="uploadImageRoute"
+    v-bind="blueprint?.props_data"
+    :modelValue="valueForField"
+    @update:modelValue="onPropertyUpdate"
+  />
+</template>
+
+<style lang="scss" scoped>
+.editor-content {
+  background-color: white;
+  border: solid;
+}
+
+.p-inputtext {
+  width: 100%;
+}
+
+.p-accordionpanel.p-accordionpanel-active > .p-accordionheader {
+  background-color: #433cc3 !important;
+  border-radius: 0 !important;
+  color: #fdfdfd !important;
+}
+
+.p-accordioncontent-content {
+  padding: 10px !important;
+  background-color: #f9f9f9 !important;
+}
+</style>

--- a/resources/js/Composables/SideEditorHelper.ts
+++ b/resources/js/Composables/SideEditorHelper.ts
@@ -39,35 +39,35 @@ import ColorProperty from '@/Components/Workshop/Properties/ColorProperty.vue'
 // Field list of SideEditor
 export const getComponent = (componentName: string) => {
     const components: Component = {
-        'text': InputText,
+        'text': InputText, //done
         'editorhtml': SideEditorInputHTML,
-        'upload_image': UploadImage,
-        'payment_templates': Payments,
-        'editor': Editor,
-        'socialMedia': socialMedia,
-        "VisibleLoggedIn": ButtonVisibleLoggedIn,
+        'upload_image': UploadImage, //done
+        'payment_templates': Payments, //done
+        'editor': Editor, //done
+        'socialMedia': socialMedia, //done
+        "VisibleLoggedIn": ButtonVisibleLoggedIn, //done
        /*  "properties": PanelProperties, */
         "overview-property" : Overview,
-        "textHeader": TextHeader,
-        "background": Background,
-        "border": Border,
-        "padding": Padding,
-        "margin": Margin,
-        "dimension": Dimension,
-        "select" : PureMultiselect,
+        "textHeader": TextHeader, //done
+        "background": Background, // done
+        "border": Border, //done
+        "padding": Padding, //done
+        "margin": Margin, //done
+        "dimension": Dimension, //done
+        "select" : PureMultiselect, // done
         "cards-property": cardsProperty,
-        "button": ButtonProperties,
-        "link": Link,
+        "button": ButtonProperties, //done
+        "link": Link, //done
         "overview_form": OverviewForm,
         "layout_type": SelectLayout,
-        "script": Script,
-        "arrayPhone":ArrayPhone,
-        "textProperty": TextProperty,
+        "script": Script, //done
+        "arrayPhone":ArrayPhone, //done
+        "textProperty": TextProperty, //done
         "images-property" : ImagesArray,
-        "numberCss" : InputNumberCss,
-        "justify-content" : JustifyContent,
-        "shadow" : Shadow,
-        "color" : ColorProperty,
+        "numberCss" : InputNumberCss, //done
+        "justify-content" : JustifyContent, //done
+        "shadow" : Shadow, // done
+        "color" : ColorProperty, //done
         "column-layout" : ColumnComponentPicker,
         "disclosure" : Disclosure,
     }

--- a/resources/js/Composables/styles.ts
+++ b/resources/js/Composables/styles.ts
@@ -98,97 +98,109 @@ export const resolveResponsiveValue = (
   
   
 
-export const getStyles = (
+  export const getStyles = (
     properties: any,
     screen: 'mobile' | 'tablet' | 'desktop' = 'desktop'
 ) => {
     if (!properties || typeof properties !== 'object') return null;
 
-    const getVal = (base: any, path?: string[]) => resolveResponsiveValue(base, screen, path);
+    const getVal = (base: any, path?: string[]) =>
+        resolveResponsiveValue(base, screen, path);
 
     const styles: Record<string, string | null> = {
-        height: getVal(properties?.dimension, ['height','value']) && properties?.dimension?.height?.unit
-            ? `${getVal(properties.dimension, ['height','value'])}${properties.dimension.height.unit}`
+        height: getVal(properties?.dimension, ['height', 'value']) && properties?.dimension?.height?.unit
+            ? `${getVal(properties.dimension, ['height', 'value'])}${properties.dimension.height.unit}`
             : null,
 
-        width: getVal(properties?.dimension, ['width','value']) && properties?.dimension?.width?.unit
-            ? `${getVal(properties.dimension, ['width','value'])}${properties.dimension.width.unit}`
+        width: getVal(properties?.dimension, ['width', 'value']) && properties?.dimension?.width?.unit
+            ? `${getVal(properties.dimension, ['width', 'value'])}${properties.dimension.width.unit}`
             : null,
 
         color: properties?.text?.color || null,
         fontFamily: properties?.text?.fontFamily || null,
         objectFit: getVal(properties?.object_fit),
         objectPosition: getVal(properties?.object_position),
-        paddingTop: getVal(properties?.padding, ['top','value']) && properties?.padding?.unit
-            ? `${getVal(properties.padding, ['top','value'])}${properties.padding.unit}`
+
+        paddingTop: getVal(properties?.padding, ['top', 'value']) && properties?.padding?.unit
+            ? `${getVal(properties.padding, ['top', 'value'])}${properties.padding.unit}`
             : null,
 
-        paddingBottom: getVal(properties?.padding, ['bottom','value']) && properties?.padding?.unit
-            ? `${getVal(properties.padding, ['bottom','value'])}${properties.padding.unit}`
+        paddingBottom: getVal(properties?.padding, ['bottom', 'value']) && properties?.padding?.unit
+            ? `${getVal(properties.padding, ['bottom', 'value'])}${properties.padding.unit}`
             : null,
 
-        paddingLeft: getVal(properties?.padding, ['left','value']) && properties?.padding?.unit
-            ? `${getVal(properties.padding, ['left','value'])}${properties.padding.unit}`
+        paddingLeft: getVal(properties?.padding, ['left', 'value']) && properties?.padding?.unit
+            ? `${getVal(properties.padding, ['left', 'value'])}${properties.padding.unit}`
             : null,
 
-        paddingRight: getVal(properties?.padding, ['right','value']) && properties?.padding?.unit
-            ? `${getVal(properties.padding, ['right','value'])}${properties.padding.unit}`
+        paddingRight: getVal(properties?.padding, ['right', 'value']) && properties?.padding?.unit
+            ? `${getVal(properties.padding, ['right', 'value'])}${properties.padding.unit}`
             : null,
 
-        marginTop: getVal(properties?.margin, ['top','value']) && properties?.margin?.unit
-            ? `${getVal(properties.margin, ['top','value'])}${properties.margin.unit}`
+        marginTop: getVal(properties?.margin, ['top', 'value']) && properties?.margin?.unit
+            ? `${getVal(properties.margin, ['top', 'value'])}${properties.margin.unit}`
             : null,
 
-        marginBottom: getVal(properties?.margin, ['bottom','value']) && properties?.margin?.unit
-            ? `${getVal(properties.margin, ['bottom','value'])}${properties.margin.unit}`
+        marginBottom: getVal(properties?.margin, ['bottom', 'value']) && properties?.margin?.unit
+            ? `${getVal(properties.margin, ['bottom', 'value'])}${properties.margin.unit}`
             : null,
 
-        marginLeft: getVal(properties?.margin, ['left','value']) && properties?.margin?.unit
-            ? `${getVal(properties.margin, ['left','value'])}${properties.margin.unit}`
+        marginLeft: getVal(properties?.margin, ['left', 'value']) && properties?.margin?.unit
+            ? `${getVal(properties.margin, ['left', 'value'])}${properties.margin.unit}`
             : null,
 
-        marginRight: getVal(properties?.margin, ['right','value']) && properties?.margin?.unit
-            ? `${getVal(properties.margin, ['right','value'])}${properties.margin.unit}`
+        marginRight: getVal(properties?.margin, ['right', 'value']) && properties?.margin?.unit
+            ? `${getVal(properties.margin, ['right', 'value'])}${properties.margin.unit}`
             : null,
 
-        background: properties?.background
-            ? properties.background.type === 'color'
-                ? properties.background.color
-                : properties.background.image?.source?.original
-                    ? `url(${properties.background.image.source.original})`
-                    : null
+        // ✅ FIXED RESPONSIVE BACKGROUND
+        background: (() => {
+            const backgroundBase = properties?.background?.[screen] ?? properties?.background;
+            const backgroundType = getVal(backgroundBase, ['type']);
+            const backgroundColor = getVal(backgroundBase, ['color']);
+            const backgroundImage = getVal(backgroundBase, ['image', 'original']);
+
+            return backgroundType === 'color'
+                ? backgroundColor
+                : backgroundImage
+                ? `url(${backgroundImage})`
+                : null;
+        })(),
+
+        borderTop: getVal(properties?.border, ['top', 'value']) && properties?.border?.unit && properties?.border?.color
+            ? `${getVal(properties.border, ['top', 'value'])}${properties.border.unit} solid ${properties.border.color}`
             : null,
 
-        borderTop: getVal(properties?.border,['top','value']) && properties?.border?.unit && properties?.border?.color
-            ? `${getVal(properties.border, ['top','value'])}${properties.border.unit} solid ${properties.border.color}`
+        borderBottom: getVal(properties?.border, ['bottom', 'value']) && properties?.border?.unit && properties?.border?.color
+            ? `${getVal(properties.border, ['bottom', 'value'])}${properties.border.unit} solid ${properties.border.color}`
             : null,
 
-        borderBottom: getVal(properties?.border, ['bottom','value']) && properties?.border?.unit && properties?.border?.color
-            ? `${getVal(properties.border, ['bottom','value'])}${properties.border.unit} solid ${properties.border.color}`
+        borderLeft: getVal(properties?.border, ['left', 'value']) && properties?.border?.unit && properties?.border?.color
+            ? `${getVal(properties.border, ['left', 'value'])}${properties.border.unit} solid ${properties.border.color}`
             : null,
 
-        borderLeft: getVal(properties?.border, ['left','value']) && properties?.border?.unit && properties?.border?.color
-            ? `${getVal(properties.border, ['left','value'])}${properties.border.unit} solid ${properties.border.color}`
+        borderRight: getVal(properties?.border, ['right', 'value']) && properties?.border?.unit && properties?.border?.color
+            ? `${getVal(properties.border, ['right', 'value'])}${properties.border.unit} solid ${properties.border.color}`
             : null,
 
-        borderRight: getVal(properties?.border, ['right','value']) && properties?.border?.unit && properties?.border?.color
-            ? `${getVal(properties.border, ['right','value'])}${properties.border.unit} solid ${properties.border.color}`
+        borderTopLeftRadius: getVal(properties?.border, ['rounded', 'topleft', 'value']) && properties?.border?.rounded?.unit
+            ? `${getVal(properties.border, ['rounded', 'topleft', 'value'])}${properties.border.rounded.unit}`
             : null,
 
-        borderTopLeftRadius: getVal(properties?.border, ['rounded','topleft','value']) && properties?.border?.rounded?.unit
-            ? `${getVal(properties.border, ['rounded','topleft','value'])}${properties.border.rounded.unit}`
+        borderTopRightRadius: getVal(properties?.border, ['rounded', 'topright', 'value']) && properties?.border?.rounded?.unit
+            ? `${getVal(properties.border, ['rounded', 'topright', 'value'])}${properties.border.rounded.unit}`
             : null,
 
-        borderTopRightRadius: getVal(properties?.border, ['rounded','topright','value']) && properties?.border?.rounded?.unit
-            ? `${getVal(properties.border, ['rounded','topright','value'])}${properties.border.rounded.unit}`
+        borderBottomLeftRadius: getVal(properties?.border, ['rounded', 'bottomleft', 'value']) && properties?.border?.rounded?.unit
+            ? `${getVal(properties.border, ['rounded', 'bottomleft', 'value'])}${properties.border.rounded.unit}`
             : null,
 
-        borderBottomLeftRadius: getVal(properties?.border, ['rounded','bottomleft','value']) && properties?.border?.rounded?.unit
-            ? `${getVal(properties.border, ['rounded','bottomleft','value'])}${properties.border.rounded.unit}`
+        borderBottomRightRadius: getVal(properties?.border, ['rounded', 'bottomright', 'value']) && properties?.border?.rounded?.unit
+            ? `${getVal(properties.border, ['rounded', 'bottomright', 'value'])}${properties.border.rounded.unit}`
             : null,
 
-        borderBottomRightRadius: getVal(properties?.border, ['rounded','bottomright','value']) && properties?.border?.rounded?.unit
-            ? `${getVal(properties.border, ['rounded','bottomright','value'])}${properties.border.rounded.unit}`
+        borderColor: getVal(properties?.border, ['color']) && properties?.border?.color
+            ? `${getVal(properties.border, ['color'])}`
             : null,
 
         gap: getVal(properties?.gap, ['value']) && properties?.gap?.unit

--- a/resources/js/Composables/styles.ts
+++ b/resources/js/Composables/styles.ts
@@ -1,6 +1,4 @@
-import JustifyContent from "@/Components/CMS/Fields/JustifyContent.vue";
-
-export const getStyles = (properties: any) => {
+/* export const getStyles = (properties: any, screens = "desktop") => {
     if (!properties || typeof properties !== 'object') {
         // If properties are missing or not an object, return null
         return null;
@@ -58,21 +56,148 @@ export const getStyles = (properties: any) => {
         boxShadow: getBoxShadowFromParts(properties?.shadow, properties?.shadowColor),
     };
     return Object.fromEntries(Object.entries(styles).filter(([_, value]) => value !== null));
+}; */
+
+export const getBoxShadowFromParts = (shadowObj: any, color: string) => {
+    if (!shadowObj || typeof shadowObj !== 'object') return null;
+
+    const unit = shadowObj.unit || 'px';
+
+    const shadowParts = Object.entries(shadowObj)
+        .filter(([key]) => key !== 'unit')
+        .map(([key, val]: [string, any]) => {
+            const value = val?.value;
+            return value != null ? `${value}${unit}` : null;
+        })
+        .filter(part => part !== null);
+
+    if (shadowParts.length === 0) return null;
+
+    const shadowString = shadowParts.join(' ');
+    return color ? `${shadowString} ${color}` : shadowString;
 };
 
-export const getBoxShadowFromParts = (shadowObj: any, color : String) => {
-    if(shadowObj){
-        let final = []
-        for (const item in shadowObj) {
-            if(item != 'unit'){
-                final.push(`${shadowObj[item].value}${shadowObj.unit}`)
-            }
-        }
-        let data =  final.join(' ')
-        if(color) return data + " " + color
-        else return data
-
-    }return null
-   
+export const resolveResponsiveValue = (
+    base: any,
+    screen: 'mobile' | 'tablet' | 'desktop',
+    path?: string[]
+  ) => {
+    if (!base || typeof base !== 'object') return base;
+  
+    const responsiveObj = base[screen];
+  
+    // Jika responsive object ada dan path bernilai, coba ambil dari situ
+    if (responsiveObj && typeof responsiveObj === 'object' && path) {
+      const resolvedFromResponsive = path.reduce((acc, key) => acc?.[key], responsiveObj);
+      if (resolvedFromResponsive !== undefined) return resolvedFromResponsive;
+    }
+  
+    // Fallback ke base biasa
+    return path ? path.reduce((acc, key) => acc?.[key], base) : base;
   };
   
+  
+
+export const getStyles = (
+    properties: any,
+    screen: 'mobile' | 'tablet' | 'desktop' = 'desktop'
+) => {
+    if (!properties || typeof properties !== 'object') return null;
+
+    const getVal = (base: any, path?: string[]) => resolveResponsiveValue(base, screen, path);
+
+    const styles: Record<string, string | null> = {
+        height: getVal(properties?.dimension, ['height','value']) && properties?.dimension?.height?.unit
+            ? `${getVal(properties.dimension, ['height','value'])}${properties.dimension.height.unit}`
+            : null,
+
+        width: getVal(properties?.dimension, ['width','value']) && properties?.dimension?.width?.unit
+            ? `${getVal(properties.dimension, ['width','value'])}${properties.dimension.width.unit}`
+            : null,
+
+        color: properties?.text?.color || null,
+        fontFamily: properties?.text?.fontFamily || null,
+        objectFit: getVal(properties?.object_fit),
+        objectPosition: getVal(properties?.object_position),
+        paddingTop: getVal(properties?.padding, ['top','value']) && properties?.padding?.unit
+            ? `${getVal(properties.padding, ['top','value'])}${properties.padding.unit}`
+            : null,
+
+        paddingBottom: getVal(properties?.padding, ['bottom','value']) && properties?.padding?.unit
+            ? `${getVal(properties.padding, ['bottom','value'])}${properties.padding.unit}`
+            : null,
+
+        paddingLeft: getVal(properties?.padding, ['left','value']) && properties?.padding?.unit
+            ? `${getVal(properties.padding, ['left','value'])}${properties.padding.unit}`
+            : null,
+
+        paddingRight: getVal(properties?.padding, ['right','value']) && properties?.padding?.unit
+            ? `${getVal(properties.padding, ['right','value'])}${properties.padding.unit}`
+            : null,
+
+        marginTop: getVal(properties?.margin, ['top','value']) && properties?.margin?.unit
+            ? `${getVal(properties.margin, ['top','value'])}${properties.margin.unit}`
+            : null,
+
+        marginBottom: getVal(properties?.margin, ['bottom','value']) && properties?.margin?.unit
+            ? `${getVal(properties.margin, ['bottom','value'])}${properties.margin.unit}`
+            : null,
+
+        marginLeft: getVal(properties?.margin, ['left','value']) && properties?.margin?.unit
+            ? `${getVal(properties.margin, ['left','value'])}${properties.margin.unit}`
+            : null,
+
+        marginRight: getVal(properties?.margin, ['right','value']) && properties?.margin?.unit
+            ? `${getVal(properties.margin, ['right','value'])}${properties.margin.unit}`
+            : null,
+
+        background: properties?.background
+            ? properties.background.type === 'color'
+                ? properties.background.color
+                : properties.background.image?.source?.original
+                    ? `url(${properties.background.image.source.original})`
+                    : null
+            : null,
+
+        borderTop: getVal(properties?.border,['top','value']) && properties?.border?.unit && properties?.border?.color
+            ? `${getVal(properties.border, ['top','value'])}${properties.border.unit} solid ${properties.border.color}`
+            : null,
+
+        borderBottom: getVal(properties?.border, ['bottom','value']) && properties?.border?.unit && properties?.border?.color
+            ? `${getVal(properties.border, ['bottom','value'])}${properties.border.unit} solid ${properties.border.color}`
+            : null,
+
+        borderLeft: getVal(properties?.border, ['left','value']) && properties?.border?.unit && properties?.border?.color
+            ? `${getVal(properties.border, ['left','value'])}${properties.border.unit} solid ${properties.border.color}`
+            : null,
+
+        borderRight: getVal(properties?.border, ['right','value']) && properties?.border?.unit && properties?.border?.color
+            ? `${getVal(properties.border, ['right','value'])}${properties.border.unit} solid ${properties.border.color}`
+            : null,
+
+        borderTopLeftRadius: getVal(properties?.border, ['rounded','topleft','value']) && properties?.border?.rounded?.unit
+            ? `${getVal(properties.border, ['rounded','topleft','value'])}${properties.border.rounded.unit}`
+            : null,
+
+        borderTopRightRadius: getVal(properties?.border, ['rounded','topright','value']) && properties?.border?.rounded?.unit
+            ? `${getVal(properties.border, ['rounded','topright','value'])}${properties.border.rounded.unit}`
+            : null,
+
+        borderBottomLeftRadius: getVal(properties?.border, ['rounded','bottomleft','value']) && properties?.border?.rounded?.unit
+            ? `${getVal(properties.border, ['rounded','bottomleft','value'])}${properties.border.rounded.unit}`
+            : null,
+
+        borderBottomRightRadius: getVal(properties?.border, ['rounded','bottomright','value']) && properties?.border?.rounded?.unit
+            ? `${getVal(properties.border, ['rounded','bottomright','value'])}${properties.border.rounded.unit}`
+            : null,
+
+        gap: getVal(properties?.gap, ['value']) && properties?.gap?.unit
+            ? `${getVal(properties.gap, ['value'])}${properties.gap.unit}`
+            : null,
+
+        justifyContent: getVal(properties?.justifyContent),
+        boxShadow: getBoxShadowFromParts(properties?.shadow, properties?.shadowColor)
+    };
+
+    return Object.fromEntries(Object.entries(styles).filter(([_, val]) => val !== null));
+};

--- a/resources/js/Pages/Grp/Web/PreviewWebpageWorkshop.vue
+++ b/resources/js/Pages/Grp/Web/PreviewWebpageWorkshop.vue
@@ -6,7 +6,7 @@
 
 <script setup lang="ts">
 import { getComponent } from "@/Composables/getWorkshopComponents"
-import { ref, onMounted } from "vue"
+import { ref, onMounted, onBeforeUnmount } from "vue"
 import WebPreview from "@/Layouts/WebPreview.vue"
 import EmptyState from "@/Components/Utils/EmptyState.vue"
 import { sendMessageToParent } from "@/Composables/Workshop"
@@ -37,6 +37,7 @@ const props = defineProps<{
 const isPreviewLoggedIn = ref(false)
 const isPreviewMode = ref(false)
 const activeBlock = ref(null)
+const screenType = ref<'mobile' | 'tablet' | 'desktop'>('desktop')
 
 const showWebpage = (activityItem) => {
 	if (activityItem?.web_block?.layout && activityItem.show) {
@@ -48,6 +49,13 @@ const showWebpage = (activityItem) => {
 
 const updateData = (newVal) => {
 	sendMessageToParent("autosave", newVal)
+}
+
+const checkScreenType = () => {
+  const width = window.innerWidth
+  if (width < 640) screenType.value = 'mobile'
+  else if (width >= 640 && width < 1024) screenType.value = 'tablet'
+  else screenType.value = 'desktop'
 }
 
 
@@ -69,6 +77,13 @@ onMounted(() => {
 			})
 		}
 	})
+	checkScreenType()
+	window.addEventListener('resize', checkScreenType)
+})
+
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', checkScreenType)
 })
 </script>
 
@@ -112,7 +127,7 @@ onMounted(() => {
 
 								<component class="w-full" :is="getComponent(activityItem.type)" :webpageData="webpage"
 									:blockData="activityItem" @autoSave="() => updateData(activityItem)"
-									v-model="activityItem.web_block.layout.data.fieldValue" />
+									v-model="activityItem.web_block.layout.data.fieldValue" :screenType="screenType"/>
 							</section>
 						</template>
 					</TransitionGroup>

--- a/resources/js/Pages/Grp/Web/PreviewWorkshop.vue
+++ b/resources/js/Pages/Grp/Web/PreviewWorkshop.vue
@@ -7,7 +7,7 @@
 <script setup lang="ts">
 import { getComponent } from '@/Composables/getWorkshopComponents'
 import { getIrisComponent } from '@/Composables/getIrisComponents'
-import { ref, onMounted, provide } from 'vue'
+import { ref, onMounted, provide, onBeforeUnmount } from 'vue'
 import WebPreview from "@/Layouts/WebPreview.vue";
 import { sendMessageToParent} from '@/Composables/Workshop'
 import RenderHeaderMenu from './RenderHeaderMenu.vue'
@@ -39,6 +39,7 @@ const isPreviewLoggedIn = ref(false)
 const { mode } = route().params;
 const isPreviewMode = ref(mode != 'iris' ? false : true)
 const isInWorkshop = route().params.isInWorkshop || false
+const screenType = ref<'mobile' | 'tablet' | 'desktop'>('desktop')
 
 const showWebpage = (activityItem) => {
     if (activityItem?.web_block?.layout && activityItem.show) {
@@ -68,6 +69,17 @@ onMounted(() => {
         }
     });
 });
+
+const checkScreenType = () => {
+  const width = window.innerWidth
+  if (width < 640) screenType.value = 'mobile'
+  else if (width >= 640 && width < 1024) screenType.value = 'tablet'
+  else screenType.value = 'desktop'
+}
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', checkScreenType)
+})
 
 
 provide('isPreviewLoggedIn', isPreviewLoggedIn)

--- a/resources/js/Pages/Iris/Home.vue
+++ b/resources/js/Pages/Iris/Home.vue
@@ -5,7 +5,7 @@
   -->
 
 <script setup lang="ts">
-import { inject, ref, onMounted } from 'vue'
+import { inject, ref, onMounted, onBeforeUnmount } from 'vue'
 import { faCheck, faPlus, faMinus } from '@fal'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { Head } from '@inertiajs/vue3'
@@ -29,6 +29,7 @@ library.add(faCheck, faPlus, faMinus)
 
 const layout = inject('layout', {})
 const isPreviewLoggedIn = ref(layout.iris.user_auth)
+const screenType = ref<'mobile' | 'tablet' | 'desktop'>('desktop')
 
 const showWebpage = (activityItem) => {
   if (activityItem?.web_block?.layout && activityItem.show) {
@@ -38,27 +39,50 @@ const showWebpage = (activityItem) => {
 }
 
 
+const checkScreenType = () => {
+  const width = window.innerWidth
+  if (width < 640) screenType.value = 'mobile'
+  else if (width >= 640 && width < 1024) screenType.value = 'tablet'
+  else screenType.value = 'desktop'
+}
+
+
+
 onMounted(() => {
   const script = document.createElement('script')
   script.type = 'application/ld+json'
   script.textContent = JSON.stringify(props.meta.structured_data)
   document.head.appendChild(script)
+  checkScreenType()
+  window.addEventListener('resize', checkScreenType)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', checkScreenType)
 })
 
 </script>
 
 <template>
-
   <Head>
     <title>{{ meta.meta_title }}</title>
     <meta name="description" :content="meta.meta_description">
   </Head>
 
+
+  <div class="text-center text-sm text-gray-600 my-4">
+  Current screen type: <strong>{{ screenType }}</strong>
+</div>
+
+
   <div class="bg-white">
     <template v-if="props.blocks?.web_blocks?.length">
       <div v-for="(activityItem, activityItemIdx) in props.blocks.web_blocks" :key="'block' + activityItem.id"
         class="w-full">
-        <component v-if="showWebpage(activityItem)" :is="getIrisComponent(activityItem.type)"
+        <component 
+          v-if="showWebpage(activityItem)" 
+          :screenType="screenType"
+          :is="getIrisComponent(activityItem.type)"
           :theme="data.published_layout.theme" :key="activityItemIdx"
           :fieldValue="activityItem.web_block.layout.data.fieldValue" />
       </div>

--- a/resources/js/Pages/Iris/Home.vue
+++ b/resources/js/Pages/Iris/Home.vue
@@ -70,9 +70,9 @@ onBeforeUnmount(() => {
   </Head>
 
 
-  <div class="text-center text-sm text-gray-600 my-4">
+ <!--  <div class="text-center text-sm text-gray-600 my-4">
   Current screen type: <strong>{{ screenType }}</strong>
-</div>
+</div> -->
 
 
   <div class="bg-white">


### PR DESCRIPTION
 
 
 **PR Summary by Typo**
------------

**Overview**
This PR enhances mobile responsiveness for the Iris website builder by adding a `screenType` prop to components and updating styling logic. It refactors several components to use `:modelValue` and `@update:modelValue` for better reactivity and removes unnecessary injections.  The PR also introduces a new `RenderFields` component to handle field rendering based on screen type.

**Key Changes**
- Added `screenType` prop to components like `CTAIris` and `CTAWorkshop` to apply screen-specific styles.
- Refactored components such as `Background`, `Border`, `Dimension`, `Padding`, `Margin`, and others to use `:modelValue` and `@update:modelValue` for two-way binding.
- Introduced a new `RenderFields` component to handle field rendering logic based on screen type.
- Updated `SideEditor` components to accommodate the `screenType` prop and rendering logic.
- Modified `getStyles` function to handle responsive values based on screen type.
- Added `useIn` property to the blueprint to control component visibility on different screen sizes.
- Added resize event listener to update `screenType` on window resize.

**Recommendations**
Not deployment ready. While the changes improve mobile responsiveness, the removal of injections like `onSaveWorkshopFromId` and `side_editor_block_id` without clear alternatives might break existing functionality.  Ensure proper state management and data persistence are implemented before merging.  Additionally, add comprehensive tests to cover the new responsive behavior and ensure no regressions.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>