### PR TITLE
Attach isdoc to pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,4 +102,5 @@ rr
 /Han/private/
 /maya/node_modules/
 /Han/node_modules/
-/isdoc-pdf/
+isdoc-pdf
+rgb.icc

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ rr
 /Han/private/
 /maya/node_modules/
 /Han/node_modules/
+/isdoc-pdf/

--- a/app/Actions/Accounting/Invoice/AttacheIsDocToInvoicePDf.php
+++ b/app/Actions/Accounting/Invoice/AttacheIsDocToInvoicePDf.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Author: Ganes <gustiganes@gmail.com>
+ * Created on: 06-05-2025, Bali, Indonesia
+ * Github: https://github.com/Ganes556
+ * Copyright: 2025
+ *
+*/
+
+namespace App\Actions\Accounting\Invoice;
+
+use App\Actions\OrgAction;
+use App\Models\Accounting\Invoice;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Storage;
+
+class AttacheIsDocToInvoicePDF extends OrgAction
+{
+    public function handle(Invoice $invoice, $pdf, string $filename): string
+    {
+        $baseDir = 'tmp/isdoc';
+        $disk = Storage::disk('local');
+
+        if (!$disk->exists($baseDir)) {
+            $disk->makeDirectory($baseDir);
+        }
+
+        $baseLocation = storage_path('app/' . $baseDir);
+        $pdfLocation = $baseLocation . DIRECTORY_SEPARATOR . $filename . '_isdoc.pdf';
+        $isdocLocation = $baseLocation . DIRECTORY_SEPARATOR . $filename . '_isdoc.xml';
+        $outputFile = $baseLocation . DIRECTORY_SEPARATOR . $filename . '_isdoc_output.pdf';
+
+        if (!$disk->exists($baseDir . '/' . $filename . '_isdoc.pdf')) {
+            $pdf->save($pdfLocation);
+        }
+
+        if (!$disk->exists($baseDir . '/' . $filename . '_isdoc.xml')) {
+            $xml = ISDocInvoice::run($invoice);
+            $disk->put($baseDir . '/' . $filename . '_isdoc.xml', $xml);
+        }
+
+        $scriptLocation = base_path();
+        $next = Process::path($scriptLocation)->run('./isdoc-pdf ' . $pdfLocation . ' ' . $isdocLocation . ' ' . $outputFile);
+
+        if ($next->successful()) {
+            return $outputFile;
+        } else {
+            throw new \Exception('ISDoc PDF generation failed: ' . $next->errorOutput());
+        }
+    }
+}

--- a/app/Actions/Accounting/Invoice/AttacheIsDocToInvoicePDf.php
+++ b/app/Actions/Accounting/Invoice/AttacheIsDocToInvoicePDf.php
@@ -31,11 +31,11 @@ class AttacheIsDocToInvoicePDF extends OrgAction
         $isdocLocation = $baseLocation . '/' . $filename . '_isdoc.xml';
         $outputFile = $baseLocation . '/' . $filename . '_isdoc_output.pdf';
 
-        if (!$disk->exists($baseDir . '/' . $filename . '_isdoc.pdf')) {
+        if ($disk->missing($baseDir . '/' . $filename . '_isdoc.pdf')) {
             $pdf->save($pdfLocation);
         }
 
-        if (!$disk->exists($baseDir . '/' . $filename . '_isdoc.xml')) {
+        if ($disk->missing($baseDir . '/' . $filename . '_isdoc.xml')) {
             $xml = ISDocInvoice::run($invoice);
             $disk->put($baseDir . '/' . $filename . '_isdoc.xml', $xml);
         }

--- a/app/Actions/Accounting/Invoice/AttacheIsDocToInvoicePDf.php
+++ b/app/Actions/Accounting/Invoice/AttacheIsDocToInvoicePDf.php
@@ -27,9 +27,9 @@ class AttacheIsDocToInvoicePDF extends OrgAction
         }
 
         $baseLocation = storage_path('app/' . $baseDir);
-        $pdfLocation = $baseLocation . DIRECTORY_SEPARATOR . $filename . '_isdoc.pdf';
-        $isdocLocation = $baseLocation . DIRECTORY_SEPARATOR . $filename . '_isdoc.xml';
-        $outputFile = $baseLocation . DIRECTORY_SEPARATOR . $filename . '_isdoc_output.pdf';
+        $pdfLocation = $baseLocation . '/' . $filename . '_isdoc.pdf';
+        $isdocLocation = $baseLocation . '/' . $filename . '_isdoc.xml';
+        $outputFile = $baseLocation . '/' . $filename . '_isdoc_output.pdf';
 
         if (!$disk->exists($baseDir . '/' . $filename . '_isdoc.pdf')) {
             $pdf->save($pdfLocation);

--- a/app/Actions/Accounting/Invoice/ISDocInvoice.php
+++ b/app/Actions/Accounting/Invoice/ISDocInvoice.php
@@ -32,9 +32,7 @@ use Adawolfa\ISDOC\Schema\Invoice\PostalAddress;
 use Adawolfa\ISDOC\Schema\Invoice\Quantity;
 use Adawolfa\ISDOC\Schema\Invoice\TaxCategory;
 use Adawolfa\ISDOC\Schema\Invoice\TaxSubTotal;
-use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
-use Mpdf\Mpdf;
 
 class ISDocInvoice extends OrgAction
 {
@@ -186,36 +184,6 @@ class ISDocInvoice extends OrgAction
 
         return $manager->writer->xml($isDocInvoice);
     }
-
-    public function attachIsdocToPdf(Invoice $invoice, Mpdf $pdf, string $filename): string
-    {
-        $baseLocation = storage_path('app/tmp/isdoc');
-        if (!file_exists($baseLocation)) {
-            mkdir($baseLocation, 0755, true);
-        }
-        $pdfLocation = $baseLocation . '/' . $filename . '_isdoc.pdf';
-        $isdocLocation = $baseLocation . '/' . $filename . '_isdoc.xml';
-        $outputFile = $baseLocation . '/' . $filename . '_isdoc_output.pdf';
-
-        if (!file_exists($pdfLocation)) {
-            $pdf->save($pdfLocation);
-        }
-
-        if (!file_exists($isdocLocation)) {
-            $xml = ISDocInvoice::run($invoice);
-            file_put_contents($isdocLocation, $xml);
-        }
-
-        $scriptLocation = base_path() . '/isdoc-pdf';
-        $next = Process::path($scriptLocation)->run('./isdoc-pdf ' . $pdfLocation . ' ' . $isdocLocation . ' ' . $outputFile);
-
-        if ($next->successful()) {
-            return $outputFile;
-        } else {
-            throw new \Exception('ISDoc PDF generation failed: ' . $next->errorOutput());
-        }
-    }
-
 
     /**
      * @throws \Adawolfa\ISDOC\WriterException

--- a/app/Actions/Accounting/Invoice/ISDocInvoice.php
+++ b/app/Actions/Accounting/Invoice/ISDocInvoice.php
@@ -32,6 +32,7 @@ use Adawolfa\ISDOC\Schema\Invoice\PostalAddress;
 use Adawolfa\ISDOC\Schema\Invoice\Quantity;
 use Adawolfa\ISDOC\Schema\Invoice\TaxCategory;
 use Adawolfa\ISDOC\Schema\Invoice\TaxSubTotal;
+use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
 
 class ISDocInvoice extends OrgAction
@@ -183,6 +184,32 @@ class ISDocInvoice extends OrgAction
 
 
         return $manager->writer->xml($isDocInvoice);
+    }
+
+    public function attachIsdocToPdf(Invoice $invoice, $pdf, string $filename): string
+    {
+        $baseLocation = storage_path('temp');
+        $pdfLocation = $baseLocation . '/' . $filename . '_isdoc.pdf';
+        $isdocLocation = $baseLocation . '/' . $filename . '_isdoc.xml';
+        $outputFile = $baseLocation . '/' . $filename . '_isdoc_output.pdf';
+
+        if (!file_exists($pdfLocation)) {
+            $pdf->save($pdfLocation);
+        }
+
+        if (!file_exists($isdocLocation)) {
+            $xml = ISDocInvoice::run($invoice);
+            file_put_contents($isdocLocation, $xml);
+        }
+
+        $scriptLocation = base_path() . '/isdoc-pdf';
+        $next = Process::path($scriptLocation)->run('./isdoc-pdf ' . $pdfLocation . ' ' . $isdocLocation . ' ' . $outputFile);
+
+        if ($next->successful()) {
+            return $outputFile;
+        } else {
+            throw new \Exception('ISDoc PDF generation failed: ' . $next->errorOutput());
+        }
     }
 
 

--- a/app/Actions/Accounting/Invoice/ISDocInvoice.php
+++ b/app/Actions/Accounting/Invoice/ISDocInvoice.php
@@ -188,7 +188,10 @@ class ISDocInvoice extends OrgAction
 
     public function attachIsdocToPdf(Invoice $invoice, $pdf, string $filename): string
     {
-        $baseLocation = storage_path('temp');
+        $baseLocation = storage_path('app/tmp/isdoc');
+        if (!file_exists($baseLocation)) {
+            mkdir($baseLocation, 0755, true);
+        }
         $pdfLocation = $baseLocation . '/' . $filename . '_isdoc.pdf';
         $isdocLocation = $baseLocation . '/' . $filename . '_isdoc.xml';
         $outputFile = $baseLocation . '/' . $filename . '_isdoc_output.pdf';

--- a/app/Actions/Accounting/Invoice/ISDocInvoice.php
+++ b/app/Actions/Accounting/Invoice/ISDocInvoice.php
@@ -34,6 +34,7 @@ use Adawolfa\ISDOC\Schema\Invoice\TaxCategory;
 use Adawolfa\ISDOC\Schema\Invoice\TaxSubTotal;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
+use Mpdf\Mpdf;
 
 class ISDocInvoice extends OrgAction
 {
@@ -186,7 +187,7 @@ class ISDocInvoice extends OrgAction
         return $manager->writer->xml($isDocInvoice);
     }
 
-    public function attachIsdocToPdf(Invoice $invoice, $pdf, string $filename): string
+    public function attachIsdocToPdf(Invoice $invoice, Mpdf $pdf, string $filename): string
     {
         $baseLocation = storage_path('app/tmp/isdoc');
         if (!file_exists($baseLocation)) {

--- a/app/Actions/Accounting/Invoice/UI/ShowInvoice.php
+++ b/app/Actions/Accounting/Invoice/UI/ShowInvoice.php
@@ -153,6 +153,20 @@ class ShowInvoice extends OrgAction
             ]
         ];
 
+        if (Arr::get($invoice->organisation->settings, 'invoice_export.show_isdoc')) {
+            $options[] = [
+                'type'       => 'isDoc',
+                'icon'       => 'fas fa-hockey-puck',
+                'tooltip'    => __('Download Doc'),
+                'label'      => 'IsDoc',
+                'name'       => 'grp.org.accounting.invoices.show.is_doc',
+                'parameters' => [
+                    'organisation' => $invoice->organisation->slug,
+                    'invoice'      => $invoice->slug
+                ]
+            ];
+        }
+
         if (Arr::get($invoice->organisation->settings, 'invoice_export.show_omega')) {
             $options[] = [
                 'type'       => 'omega',

--- a/app/Actions/Accounting/Invoice/UI/ShowInvoice.php
+++ b/app/Actions/Accounting/Invoice/UI/ShowInvoice.php
@@ -153,20 +153,6 @@ class ShowInvoice extends OrgAction
             ]
         ];
 
-        if (Arr::get($invoice->organisation->settings, 'invoice_export.show_isdoc')) {
-            $options[] = [
-                'type'       => 'isDoc',
-                'icon'       => 'fas fa-hockey-puck',
-                'tooltip'    => __('Download Doc'),
-                'label'      => 'IsDoc',
-                'name'       => 'grp.org.accounting.invoices.show.is_doc',
-                'parameters' => [
-                    'organisation' => $invoice->organisation->slug,
-                    'invoice'      => $invoice->slug
-                ]
-            ];
-        }
-
         if (Arr::get($invoice->organisation->settings, 'invoice_export.show_omega')) {
             $options[] = [
                 'type'       => 'omega',

--- a/app/Actions/Accounting/Invoice/WithInvoicesExport.php
+++ b/app/Actions/Accounting/Invoice/WithInvoicesExport.php
@@ -63,7 +63,7 @@ trait WithInvoicesExport
                 'totalNet'      => number_format($totalNet, 2, '.', ''),
             ], [], $config);
 
-            $isAttachIsdocToPdf = Arr::get($invoice->shop->settings, "invoice_export.attach_isdoc_to_pdf", true);
+            $isAttachIsdocToPdf = Arr::get($invoice->organisation->settings, "invoice_export.attach_isdoc_to_pdf", false);
 
             if ($isAttachIsdocToPdf) {
                 try {

--- a/app/Actions/Accounting/Invoice/WithInvoicesExport.php
+++ b/app/Actions/Accounting/Invoice/WithInvoicesExport.php
@@ -67,7 +67,8 @@ trait WithInvoicesExport
 
             if ($isAttachIsdocToPdf) {
                 try {
-                    $outputFile = ISDocInvoice::make()->attachIsdocToPdf($invoice, $pdf, $filename);
+                    $mpdfInstance = $pdf->getMpdf();
+                    $outputFile = ISDocInvoice::make()->attachIsdocToPdf($invoice, $mpdfInstance, $filename);
                     return response()->file($outputFile, [
                         'Content-Type' => 'application/pdf',
                         'Content-Disposition' => 'inline; filename="' . $filename . '.pdf"',

--- a/app/Actions/Accounting/Invoice/WithInvoicesExport.php
+++ b/app/Actions/Accounting/Invoice/WithInvoicesExport.php
@@ -14,6 +14,7 @@ use App\Models\Accounting\Invoice;
 use App\Models\Fulfilment\Pallet;
 use Carbon\Carbon;
 use Exception;
+use Illuminate\Support\Arr;
 use Mccarlosen\LaravelMpdf\Facades\LaravelMpdf as PDF;
 
 trait WithInvoicesExport
@@ -50,7 +51,7 @@ trait WithInvoicesExport
                 'margin_top'             => 2,
                 'margin_bottom'          => 2,
                 'auto_page_break'        => true,
-                'auto_page_break_margin' => 10
+                'auto_page_break_margin' => 10,
             ];
 
             $filename = $invoice->slug . '-' . now()->format('Y-m-d');
@@ -61,6 +62,20 @@ trait WithInvoicesExport
                 'transactions'  => $transactions,
                 'totalNet'      => number_format($totalNet, 2, '.', ''),
             ], [], $config);
+
+            $isAttachIsdocToPdf = Arr::get($invoice->shop->settings, "invoice_export.attach_isdoc_to_pdf", false);
+
+            if ($isAttachIsdocToPdf) {
+                try {
+                    $outputFile = ISDocInvoice::make()->attachIsdocToPdf($invoice, $pdf, $filename);
+                    return response()->file($outputFile, [
+                        'Content-Type' => 'application/pdf',
+                        'Content-Disposition' => 'inline; filename="' . $filename . '.pdf"',
+                    ]);
+                } catch (Exception $e) {
+                    return response()->json(['error' => 'Failed to generate ISDOC'], 404);
+                }
+            }
 
             return response($pdf->stream(), 200)
                 ->header('Content-Type', 'application/pdf')

--- a/app/Actions/Accounting/Invoice/WithInvoicesExport.php
+++ b/app/Actions/Accounting/Invoice/WithInvoicesExport.php
@@ -67,8 +67,7 @@ trait WithInvoicesExport
 
             if ($isAttachIsdocToPdf) {
                 try {
-                    $mpdfInstance = $pdf->getMpdf();
-                    $outputFile = ISDocInvoice::make()->attachIsdocToPdf($invoice, $mpdfInstance, $filename);
+                    $outputFile = AttacheIsDocToInvoicePDf::make()->handle($invoice, $pdf, $filename);
                     return response()->file($outputFile, [
                         'Content-Type' => 'application/pdf',
                         'Content-Disposition' => 'inline; filename="' . $filename . '.pdf"',

--- a/app/Actions/Accounting/Invoice/WithInvoicesExport.php
+++ b/app/Actions/Accounting/Invoice/WithInvoicesExport.php
@@ -77,7 +77,7 @@ trait WithInvoicesExport
                 }
             }
 
-            return response($pdf->stream(), 200)
+            return response($pdf->stream($filename . '.pdf'), 200)
                 ->header('Content-Type', 'application/pdf')
                 ->header('Content-Disposition', 'inline; filename="' . $filename . '.pdf"');
         } catch (Exception $e) {

--- a/app/Actions/Accounting/Invoice/WithInvoicesExport.php
+++ b/app/Actions/Accounting/Invoice/WithInvoicesExport.php
@@ -63,7 +63,7 @@ trait WithInvoicesExport
                 'totalNet'      => number_format($totalNet, 2, '.', ''),
             ], [], $config);
 
-            $isAttachIsdocToPdf = Arr::get($invoice->shop->settings, "invoice_export.attach_isdoc_to_pdf", false);
+            $isAttachIsdocToPdf = Arr::get($invoice->shop->settings, "invoice_export.attach_isdoc_to_pdf", true);
 
             if ($isAttachIsdocToPdf) {
                 try {

--- a/app/Actions/Helpers/Isdoc/DeleteTempIsdoc.php
+++ b/app/Actions/Helpers/Isdoc/DeleteTempIsdoc.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Author: Ganes <gustiganes@gmail.com>
+ * Created on: 06-05-2025, Bali, Indonesia
+ * Github: https://github.com/Ganes556
+ * Copyright: 2025
+ *
+*/
+
+namespace App\Actions\Helpers\Isdoc;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class DeleteTempIsdoc
+{
+    use AsAction;
+
+    public string $commandSignature =  'isdoc:delete_temp';
+    public string $commandDescription = 'Delete isdoc temp';
+
+    public function handle(): void
+    {
+        $location = storage_path('app/tmp/isdoc');
+
+        if (is_dir($location)) {
+            $files = glob($location . '/*');
+
+            foreach ($files as $file) {
+                if (is_file($file)) {
+                    unlink($file);
+                }
+            }
+        }
+    }
+
+    public function asCommand($command)
+    {
+
+        $this->handle();
+    }
+
+
+}

--- a/app/Actions/Helpers/Isdoc/DeleteTempIsdoc.php
+++ b/app/Actions/Helpers/Isdoc/DeleteTempIsdoc.php
@@ -10,6 +10,7 @@
 
 namespace App\Actions\Helpers\Isdoc;
 
+use Illuminate\Support\Facades\Storage;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class DeleteTempIsdoc
@@ -21,15 +22,14 @@ class DeleteTempIsdoc
 
     public function handle(): void
     {
-        $location = storage_path('app/tmp/isdoc');
+        $disk = Storage::disk('local');
+        $directory = 'tmp/isdoc';
 
-        if (is_dir($location)) {
-            $files = glob($location . '/*');
+        if ($disk->exists($directory)) {
+            $files = $disk->files($directory);
 
             foreach ($files as $file) {
-                if (is_file($file)) {
-                    unlink($file);
-                }
+                $disk->delete($file);
             }
         }
     }

--- a/app/Actions/SysAdmin/Organisation/UI/EditOrganisationSettings.php
+++ b/app/Actions/SysAdmin/Organisation/UI/EditOrganisationSettings.php
@@ -117,6 +117,11 @@ class EditOrganisationSettings extends OrgAction
                                     'label' => __('Show ISDoc invoice'),
                                     'value' => Arr::get($organisation->settings, 'invoice_export.show_isdoc', false),
                                 ],
+                                'attach_isdoc_to_pdf' => [
+                                    'type'  => 'toggle',
+                                    'label' => __('Attach ISDoc to invoice pdf'),
+                                    'value' => Arr::get($organisation->settings, 'invoice_export.attach_isdoc_to_pdf', false),
+                                ],
                                 'show_omega' => [
                                     'type'  => 'toggle',
                                     'label' => __('Show Omega'),

--- a/app/Actions/SysAdmin/Organisation/UI/EditOrganisationSettings.php
+++ b/app/Actions/SysAdmin/Organisation/UI/EditOrganisationSettings.php
@@ -112,6 +112,11 @@ class EditOrganisationSettings extends OrgAction
                             "label"  => __("Invoice formats"),
                             "icon"   => "fa-light fa-file-invoice",
                             "fields" => [
+                                'show_isdoc' => [
+                                    'type'  => 'toggle',
+                                    'label' => __('Show ISDoc invoice'),
+                                    'value' => Arr::get($organisation->settings, 'invoice_export.show_isdoc', false),
+                                ],
                                 'attach_isdoc_to_pdf' => [
                                     'type'  => 'toggle',
                                     'label' => __('Attach ISDoc to invoice pdf'),

--- a/app/Actions/SysAdmin/Organisation/UI/EditOrganisationSettings.php
+++ b/app/Actions/SysAdmin/Organisation/UI/EditOrganisationSettings.php
@@ -112,11 +112,6 @@ class EditOrganisationSettings extends OrgAction
                             "label"  => __("Invoice formats"),
                             "icon"   => "fa-light fa-file-invoice",
                             "fields" => [
-                                'show_isdoc' => [
-                                    'type'  => 'toggle',
-                                    'label' => __('Show ISDoc invoice'),
-                                    'value' => Arr::get($organisation->settings, 'invoice_export.show_isdoc', false),
-                                ],
                                 'attach_isdoc_to_pdf' => [
                                     'type'  => 'toggle',
                                     'label' => __('Attach ISDoc to invoice pdf'),

--- a/app/Actions/SysAdmin/Organisation/UpdateOrganisation.php
+++ b/app/Actions/SysAdmin/Organisation/UpdateOrganisation.php
@@ -111,7 +111,6 @@ class UpdateOrganisation extends OrgAction
             'contact_name'            => ['sometimes', 'string', 'max:255'],
             'google_client_id'        => ['sometimes', 'string'],
             'google_client_secret'    => ['sometimes', 'string'],
-            'show_isdoc'              => ['sometimes', 'boolean'],
             'show_omega'              => ['sometimes', 'boolean'],
             'attach_isdoc_to_pdf'     => ['sometimes', 'boolean'],
             'google_drive_folder_key' => ['sometimes', 'string'],

--- a/app/Actions/SysAdmin/Organisation/UpdateOrganisation.php
+++ b/app/Actions/SysAdmin/Organisation/UpdateOrganisation.php
@@ -48,6 +48,10 @@ class UpdateOrganisation extends OrgAction
             data_set($modelData, "settings.invoice_export.show_omega", Arr::pull($modelData, 'show_omega'));
         }
 
+        if (Arr::has($modelData, 'attach_isdoc_to_pdf')) {
+            data_set($modelData, "settings.invoice_export.attach_isdoc_to_pdf", Arr::pull($modelData, 'attach_isdoc_to_pdf'));
+        }
+
 
         if (Arr::has($modelData, 'address')) {
             $addressData = Arr::get($modelData, 'address');
@@ -109,6 +113,7 @@ class UpdateOrganisation extends OrgAction
             'google_client_secret'    => ['sometimes', 'string'],
             'show_isdoc'              => ['sometimes', 'boolean'],
             'show_omega'              => ['sometimes', 'boolean'],
+            'attach_isdoc_to_pdf'     => ['sometimes', 'boolean'],
             'google_drive_folder_key' => ['sometimes', 'string'],
             'address'                 => ['sometimes', 'required', new ValidAddress()],
             'language_id'             => ['sometimes', 'exists:languages,id'],

--- a/app/Actions/SysAdmin/Organisation/UpdateOrganisation.php
+++ b/app/Actions/SysAdmin/Organisation/UpdateOrganisation.php
@@ -111,6 +111,7 @@ class UpdateOrganisation extends OrgAction
             'contact_name'            => ['sometimes', 'string', 'max:255'],
             'google_client_id'        => ['sometimes', 'string'],
             'google_client_secret'    => ['sometimes', 'string'],
+            'show_isdoc'              => ['sometimes', 'boolean'],
             'show_omega'              => ['sometimes', 'boolean'],
             'attach_isdoc_to_pdf'     => ['sometimes', 'boolean'],
             'google_drive_folder_key' => ['sometimes', 'string'],

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -11,6 +11,7 @@ use App\Actions\Helpers\Intervals\ResetMonthlyIntervals;
 use App\Actions\Helpers\Intervals\ResetQuarterlyIntervals;
 use App\Actions\Helpers\Intervals\ResetWeeklyIntervals;
 use App\Actions\Helpers\Intervals\ResetYearIntervals;
+use App\Actions\Helpers\Isdoc\DeleteTempIsdoc;
 use App\Actions\Transfers\FetchStack\ProcessFetchStacks;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -57,6 +58,10 @@ class Kernel extends ConsoleKernel
             monitorSlug: 'PurgeWebUserPasswordReset',
         );
 
+        $schedule->job(DeleteTempIsdoc::makeJob())->dailyAt('00:00')->timezone('UTC')->sentryMonitor(
+            monitorSlug: 'DeleteTempIsdoc',
+        );
+
         $schedule->command('fetch:orders -w full -B')->everyFiveMinutes()->timezone('UTC')->sentryMonitor(
             monitorSlug: 'FetchOrdersInBasket',
         );
@@ -80,6 +85,7 @@ class Kernel extends ConsoleKernel
         $schedule->job(ProcessFetchStacks::makeJob())->everyMinute()->timezone('UTC')->sentryMonitor(
             monitorSlug: 'ProcessFetchStacks',
         );
+
     }
 
 


### PR DESCRIPTION
 
 
 
 
 
 
 
 
 **PR Summary by Typo**
------------

**Overview**
This PR implements a feature to attach ISDOC XML data to invoice PDFs. It introduces new actions for attaching ISDOC to PDF, deleting temporary ISDOC files, and updates the organization settings UI to include a toggle for enabling this feature.

**Key Changes**
- Added `AttacheIsDocToInvoicePDf` action to handle merging ISDOC XML with the PDF.
- Added `DeleteTempIsdoc` action and scheduled job to clean up temporary files.
- Added a toggle in organization settings to control ISDOC attachment.
- Modified `WithInvoicesExport` to conditionally attach ISDOC based on the new setting.
- Updated `.gitignore` to exclude ISDOC related files.

**Recommendations**
Not deployment ready.  While the core functionality seems implemented, consider adding more robust error handling within the `AttacheIsDocToInvoicePDf` action to gracefully handle potential issues during PDF manipulation or ISDOC generation.  Additionally, logging should be added to track successes and failures of the ISDOC attachment process.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>