### PR TITLE
Packing DeliveryNote

### DIFF
--- a/app/Actions/Dispatching/DeliveryNote/SetDeliveryNoteStateAsPacked.php
+++ b/app/Actions/Dispatching/DeliveryNote/SetDeliveryNoteStateAsPacked.php
@@ -8,6 +8,7 @@
 
 namespace App\Actions\Dispatching\DeliveryNote;
 
+use App\Actions\Dispatching\Packing\StorePacking;
 use App\Actions\OrgAction;
 use App\Actions\Traits\WithActionUpdate;
 use App\Enums\Dispatching\DeliveryNote\DeliveryNoteStateEnum;
@@ -25,7 +26,15 @@ class SetDeliveryNoteStateAsPacked extends OrgAction
         data_set($modelData, 'packed_at', now());
         data_set($modelData, 'state', DeliveryNoteStateEnum::PACKED->value);
 
-        return $this->update($deliveryNote, $modelData);
+        foreach ($deliveryNote->deliveryNoteItems as $item) {
+            StorePacking::make()->action($item, []);
+        }
+        
+        $deliveryNote = $this->update($deliveryNote, $modelData);
+
+        $deliveryNote->refresh();
+
+        return $deliveryNote;
     }
 
 

--- a/app/Actions/Dispatching/DeliveryNote/SetDeliveryNoteStateAsPacked.php
+++ b/app/Actions/Dispatching/DeliveryNote/SetDeliveryNoteStateAsPacked.php
@@ -26,10 +26,9 @@ class SetDeliveryNoteStateAsPacked extends OrgAction
         data_set($modelData, 'packed_at', now());
         data_set($modelData, 'state', DeliveryNoteStateEnum::PACKED->value);
 
-        foreach ($deliveryNote->deliveryNoteItems as $item) {
+        foreach ($deliveryNote->deliveryNoteItems->filter(fn($item) => $item->packings->isEmpty()) as $item) {
             StorePacking::make()->action($item, []);
         }
-        
         $deliveryNote = $this->update($deliveryNote, $modelData);
 
         $deliveryNote->refresh();

--- a/app/Actions/Dispatching/DeliveryNote/UI/ShowDeliveryNote.php
+++ b/app/Actions/Dispatching/DeliveryNote/UI/ShowDeliveryNote.php
@@ -132,6 +132,10 @@ class ShowDeliveryNote extends OrgAction
 
         $estWeight = ($deliveryNote->estimated_weight ?? 0) / 1000;
 
+        $isSomeNotPicked = !$deliveryNote->deliveryNoteItems->every(
+            fn ($item) => $item->pickings->isNotEmpty() && $item->is_completed === true
+        );
+
         $actions = [];
 
         $actions = match ($deliveryNote->state) {
@@ -182,6 +186,21 @@ class ShowDeliveryNote extends OrgAction
                     ]
             ],
             DeliveryNoteStateEnum::HANDLING => [
+                [
+                    'type'    => 'button',
+                    'style'   => 'save',
+                    'tooltip' => __('Set as packed'),
+                    'label'   => __('Set as packed'),
+                    'disabled' => $isSomeNotPicked,
+                    'key'     => 'action',
+                    'route'   => [
+                        'method'     => 'patch',
+                        'name'       => 'grp.models.delivery-note.state.packed',
+                        'parameters' => [
+                            'deliveryNote' => $deliveryNote->id
+                        ]
+                    ]
+                ],
                 [
                     'type'    => 'button',
                     'style'   => 'save',

--- a/app/Actions/Dispatching/DeliveryNoteItem/CalculateDeliveryNoteItemTotalPacked.php
+++ b/app/Actions/Dispatching/DeliveryNoteItem/CalculateDeliveryNoteItemTotalPacked.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * author Arya Permana - Kirin
+ * created on 26-05-2025-16h-16m
+ * github: https://github.com/KirinZero0
+ * copyright 2025
+*/
+
+namespace App\Actions\Dispatching\DeliveryNoteItem;
+
+use App\Actions\OrgAction;
+use App\Actions\Traits\Rules\WithNoStrictRules;
+use App\Actions\Traits\WithActionUpdate;
+use App\Enums\Dispatching\DeliveryNoteItem\DeliveryNoteItemStateEnum;
+use App\Enums\Dispatching\Picking\PickingTypeEnum;
+use App\Models\Dispatching\DeliveryNoteItem;
+
+class CalculateDeliveryNoteItemTotalPacked extends OrgAction
+{
+    use WithActionUpdate;
+    use WithNoStrictRules;
+    use WithDeliveryNoteItemNoStrictRules;
+
+    public function handle(DeliveryNoteItem $deliveryNoteItem): DeliveryNoteItem
+    {
+        $totalPacked = $deliveryNoteItem->packings()->sum('quantity');
+        $state = $deliveryNoteItem->state;
+        
+        if ($totalPacked == $deliveryNoteItem->quantity_picked) {
+            $state = DeliveryNoteItemStateEnum::PACKED;
+        }
+
+        return $this->update($deliveryNoteItem, [
+            'quantity_packed' => $totalPacked,
+            'state' => $state
+        ]);
+    }
+
+    public function action(DeliveryNoteItem $deliveryNoteItem): DeliveryNoteItem
+    {
+        $this->initialisationFromShop($deliveryNoteItem->shop, []);
+
+        return $this->handle($deliveryNoteItem);
+    }
+}

--- a/app/Actions/Dispatching/Packing/StorePacking.php
+++ b/app/Actions/Dispatching/Packing/StorePacking.php
@@ -9,9 +9,11 @@
 
 namespace App\Actions\Dispatching\Packing;
 
+use App\Actions\Dispatching\DeliveryNoteItem\CalculateDeliveryNoteItemTotalPacked;
 use App\Actions\OrgAction;
 use App\Enums\Dispatching\Packing\PackingEngineEnum;
 use App\Enums\Dispatching\Packing\PackingStateEnum;
+use App\Models\Dispatching\DeliveryNoteItem;
 use App\Models\Dispatching\Packing;
 use App\Models\Dispatching\Picking;
 use Illuminate\Validation\Rule;
@@ -24,45 +26,59 @@ class StorePacking extends OrgAction
     use AsAction;
     use WithAttributes;
 
-    protected Picking $picking;
+    protected DeliveryNoteItem $deliveryNoteItem;
 
-    public function handle(Picking $picking, array $modelData): Packing
+    public function handle(DeliveryNoteItem $deliveryNoteItem, array $modelData): Packing
     {
-        data_set($modelData, 'group_id', $picking->group_id);
-        data_set($modelData, 'organisation_id', $picking->organisation_id);
-        data_set($modelData, 'shop_id', $picking->shop_id);
-        data_set($modelData, 'delivery_note_id', $picking->delivery_note_id);
-        data_set($modelData, 'picking_id', $picking->id);
+        data_set($modelData, 'group_id', $deliveryNoteItem->group_id);
+        data_set($modelData, 'organisation_id', $deliveryNoteItem->organisation_id);
+        data_set($modelData, 'shop_id', $deliveryNoteItem->shop_id);
+        data_set($modelData, 'delivery_note_id', $deliveryNoteItem->delivery_note_id);
+        data_set($modelData, 'engine', PackingEngineEnum::AIKU);
 
-        return $picking->deliveryNoteItem->packings()->create($modelData);
+        $packing = $deliveryNoteItem->packings()->create($modelData);
+
+        CalculateDeliveryNoteItemTotalPacked::make()->action($deliveryNoteItem);
+
+        $packing->refresh();
+        
+        return $packing;
     }
 
     public function rules(): array
     {
         return [
-            'state'           => ['sometimes', Rule::enum(PackingStateEnum::class)],
-            'engine'          => ['sometimes', Rule::enum(PackingEngineEnum::class)],
-            'quantity_packed' => ['sometimes', 'numeric'],
-            'packer_id'       => [
-                'sometimes',
+            'quantity' => ['sometimes', 'numeric'],
+            'packer_user_id'       => [
+                'required',
                 Rule::Exists('users', 'id')->where('group_id', $this->shop->group_id)
             ],
         ];
     }
 
-    public function asController(Picking $picking, ActionRequest $request): Packing
+    public function prepareForValidation(ActionRequest $request)
     {
-        $this->picking = $picking;
-        $this->initialisationFromShop($picking->shop, $request);
-
-        return $this->handle($picking, $this->validatedData);
+        if (!$request->has('packer_user_id')) {
+            $this->set('packer_user_id', $request->user()->id);
+        }
+        if (!$request->has('quantity')) {
+            $this->set('quantity', $this->deliveryNoteItem->quantity_picked);
+        }
     }
 
-    public function action(Picking $picking, array $modelData): Packing
+    public function asController(DeliveryNoteItem $deliveryNoteItem, ActionRequest $request)
     {
-        $this->picking = $picking;
-        $this->initialisationFromShop($picking->shop, $modelData);
+        $this->deliveryNoteItem = $deliveryNoteItem;
+        $this->initialisationFromShop($deliveryNoteItem->shop, $request);
 
-        return $this->handle($picking, $this->validatedData);
+        $this->handle($deliveryNoteItem, $this->validatedData);
+    }
+
+    public function action(DeliveryNoteItem $deliveryNoteItem, array $modelData): Packing
+    {
+        $this->deliveryNoteItem = $deliveryNoteItem;
+        $this->initialisationFromShop($deliveryNoteItem->shop, $modelData);
+
+        return $this->handle($deliveryNoteItem, $this->validatedData);
     }
 }

--- a/app/Http/Resources/Dispatching/DeliveryNoteItemsResource.php
+++ b/app/Http/Resources/Dispatching/DeliveryNoteItemsResource.php
@@ -76,6 +76,13 @@ class DeliveryNoteItemsResource extends JsonResource
                 ],
                 'method' => 'post'
             ],
+            'packing_route'       => [
+                'name' => 'grp.models.delivery-note-item.packing.store',
+                'parameters' => [
+                    'deliveryNoteItem' => $this->id
+                ],
+                'method' => 'post'
+            ],
             'pickers_list_route'   => [
                 'name'       => 'grp.json.employees.picker_users',
                 'parameters' => [

--- a/app/Http/Resources/Dispatching/DeliveryNoteItemsResource.php
+++ b/app/Http/Resources/Dispatching/DeliveryNoteItemsResource.php
@@ -55,6 +55,7 @@ class DeliveryNoteItemsResource extends JsonResource
             'packings'            => $deliveryNoteItem->packings ? PackingsResource::collection($deliveryNoteItem->packings) : [],
             'warning'             => $fullWarning,
             'is_completed'        => $this->is_completed,
+            'is_packed'           => $this->quantity_packed == $this->quantity_picked,
             'picking_route'       => [
                 'name' => 'grp.models.delivery-note-item.picking.store',
                 'parameters' => [

--- a/app/Http/Resources/Dispatching/PackingsResource.php
+++ b/app/Http/Resources/Dispatching/PackingsResource.php
@@ -17,9 +17,7 @@ class PackingsResource extends JsonResource
     {
         return [
             'id'                  => $this->id,
-            'state'               => $this->state,
-            'picking'             => PickingsResource::make($this->picking),
-            'quantity_packed'     => $this->quantity_packed,
+            'quantity'            => $this->quantity,
             'engine'              => $this->engine,
             'packer'              => $this->packer->contact_name
         ];

--- a/app/Models/Dispatching/Packing.php
+++ b/app/Models/Dispatching/Packing.php
@@ -54,7 +54,6 @@ class Packing extends Model
     protected $casts = [
         'data'   => 'array',
         'engine' => PackingEngineEnum::class,
-        'state'  => PackingStateEnum::class
     ];
 
     protected $guarded = [];
@@ -63,19 +62,19 @@ class Packing extends Model
         'data' => '{}',
     ];
 
-    public function picking(): BelongsTo
-    {
-        return $this->belongsTo(Picking::class);
-    }
-
     public function deliveryNoteItem(): BelongsTo
     {
         return $this->belongsTo(DeliveryNoteItem::class);
     }
 
+    public function deliveryNote(): BelongsTo
+    {
+        return $this->belongsTo(DeliveryNote::class);
+    }
+
     public function packer(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'packer_id');
+        return $this->belongsTo(User::class, 'packer_user_id');
     }
 
 

--- a/database/migrations/2025_05_26_075834_change_columns_in_packings_table.php
+++ b/database/migrations/2025_05_26_075834_change_columns_in_packings_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\Dispatching\Packing\PackingStateEnum;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -19,6 +20,7 @@ return new class extends Migration
             $table->dropForeign(['picking_id']);
 
             $table->dropColumn('picking_id');
+            $table->dropColumn('state');
         });
     }
 
@@ -33,6 +35,7 @@ return new class extends Migration
             $table->renameColumn('quantity', 'quantity_packed');
             $table->unsignedBigInteger('picking_id')->nullable();
             $table->foreign('picking_id')->references('id')->on('pickings');
+            $table->string('state')->default(PackingStateEnum::QUEUED->value)->index();
         });
     }
 };

--- a/database/migrations/2025_05_26_075834_change_columns_in_packings_table.php
+++ b/database/migrations/2025_05_26_075834_change_columns_in_packings_table.php
@@ -16,6 +16,7 @@ return new class extends Migration
     {
         Schema::table('packings', function (Blueprint $table) {
             $table->renameColumn('quantity_packed', 'quantity');
+            $table->renameColumn('packer_id', 'packer_user_id');
 
             $table->dropForeign(['picking_id']);
 
@@ -33,6 +34,7 @@ return new class extends Migration
     {
         Schema::table('packings', function (Blueprint $table) {
             $table->renameColumn('quantity', 'quantity_packed');
+            $table->renameColumn('packer_user_id', 'packer_id');
             $table->unsignedBigInteger('picking_id')->nullable();
             $table->foreign('picking_id')->references('id')->on('pickings');
             $table->string('state')->default(PackingStateEnum::QUEUED->value)->index();

--- a/database/migrations/2025_05_26_075834_change_columns_in_packings_table.php
+++ b/database/migrations/2025_05_26_075834_change_columns_in_packings_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('packings', function (Blueprint $table) {
+            $table->renameColumn('quantity_packed', 'quantity');
+
+            $table->dropForeign(['picking_id']);
+
+            $table->dropColumn('picking_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('packings', function (Blueprint $table) {
+            $table->renameColumn('quantity', 'quantity_packed');
+            $table->unsignedBigInteger('picking_id')->nullable();
+            $table->foreign('picking_id')->references('id')->on('pickings');
+        });
+    }
+};

--- a/resources/js/Components/Table/HeaderCell.vue
+++ b/resources/js/Components/Table/HeaderCell.vue
@@ -52,7 +52,7 @@ const isCellNumber = () => {
     <th v-show="!cell?.hidden" class="font-normal"
         :class="[
             cell?.type == 'avatar' || cell?.type == 'icon' ? 'px-5 w-1' : 'px-6 w-auto',
-            cell?.align === 'right' || isCellNumber() || cell?.type == 'number' || cell?.type == 'currency' || cell.type === 'date' || cell.type === 'date_hm' || cell.type === 'date_hms' ? 'text-right' : 'text-left'
+            cell?.align === 'right' || isCellNumber() || cell?.type == 'number' || cell?.type == 'currency' || cell?.type === 'date' || cell?.type === 'date_hm' || cell?.type === 'date_hms' ? 'text-right' : 'text-left'
         ]"
     >
         <component :is="cell?.sortable ? 'button' : 'div'" class="py-1"

--- a/resources/js/Components/Warehouse/DeliveryNotes/TableSKOSOrdered.vue
+++ b/resources/js/Components/Warehouse/DeliveryNotes/TableSKOSOrdered.vue
@@ -289,8 +289,8 @@ const onUndoPick = async (routeTarget: routeType, pallet_stored_item: any, loadi
 
         <template #cell(quantity_to_pick)="{ item: deliveryNote }">
             <template v-if="state === 'handling'">
-                <div v-if="!deliveryNote.is_completed || deliveryNote.quantity_not_picked === 0" >
-                    {{ deliveryNote.quantity_to_pick }}
+                <div v-if="!deliveryNote.is_completed || deliveryNote.quantity_not_picked === 0" class="whitespace-nowrap space-x-2">
+                    <span class="mr-0.5">{{ deliveryNote.quantity_to_pick }}</span>
                     <ButtonWithLink
                         v-if="!deliveryNote.is_completed"
                         type="negative"
@@ -316,20 +316,24 @@ const onUndoPick = async (routeTarget: routeType, pallet_stored_item: any, loadi
         </template>
 
         <template #cell(action)="{ item: deliveryNote }">
-            <ButtonWithLink
-                v-if="deliveryNote.is_completed && (state === 'handling' || state === 'handling_blocked')"
-                :routeTarget="deliveryNote.packing_route"
-                :bindToLink="{
-                    preserveScroll: true,
-                    preserveState: true,
-                }"
-                :key="deliveryNote.is_packed"
-                :type="deliveryNote.is_packed ? 'positive' : 'secondary'"
-                :icon="deliveryNote.is_packed ? 'fal fa-check' : undefined"
-                size="xs"
-                :label="deliveryNote.is_packed ? trans('Packed') : trans('Pack')"
-                :disabled="deliveryNote.is_packed"
-            />
+            <template v-if="deliveryNote.is_completed && (state === 'handling' || state === 'handling_blocked')">
+                <ButtonWithLink
+                    v-if="!deliveryNote.is_packed"
+                    :routeTarget="deliveryNote.packing_route"
+                    :bindToLink="{
+                        preserveScroll: true,
+                        preserveState: true,
+                    }"
+                    type="secondary"
+                    size="xs"
+                    :label="trans('Pack')"
+                />
+
+                <div v-else class="whitespace-nowrap text-green-600">
+                    <FontAwesomeIcon icon="fal fa-check" class="" fixed-width aria-hidden="true" />
+                    {{ trans("Packed") }}
+                </div>
+            </template>
         </template>
     </Table>
 </template>

--- a/resources/js/Components/Warehouse/DeliveryNotes/TableSKOSOrdered.vue
+++ b/resources/js/Components/Warehouse/DeliveryNotes/TableSKOSOrdered.vue
@@ -151,7 +151,7 @@ const onUndoPick = async (routeTarget: routeType, pallet_stored_item: any, loadi
             <div v-if="state === 'handling'" class="text-left">
                 <template v-for="(location, locIndex) in itemValue.locations" :key="location.location.id">
                     <Teleport v-if="isMounted" :to="`#row-${itemValue.id}`" :disabled="location.quantity > 0">
-                        <div class="rounded p-1 flex justify-between gap-x-6 items-center even:bg-indigo-50">
+                        <div class="rounded p-1 flex justify-between gap-x-6 items-center even:bg-black/5">
     
                             <!-- Location code -->
                             <div class="">
@@ -220,6 +220,7 @@ const onUndoPick = async (routeTarget: routeType, pallet_stored_item: any, loadi
                                                     class="py-0"
                                                 /> -->
                                                 <ButtonWithLink
+                                                    v-tooltip="trans('Pick all required quantity in this location')"
                                                     icon="fal fa-save"
                                                     :disabled="itemValue.is_completed || itemValue.quantity_required == itemValue.quantity_picked"
                                                     :label="trans('Pick all')"
@@ -315,7 +316,20 @@ const onUndoPick = async (routeTarget: routeType, pallet_stored_item: any, loadi
         </template>
 
         <template #cell(action)="{ item: deliveryNote }">
+            <ButtonWithLink
+                v-if="deliveryNote.is_completed && (state === 'handling' || state === 'handling_blocked')"
+                :routeTarget="deliveryNote.packing_route"
+                :bindToLink="{
+                    preserveScroll: true,
+                    preserveState: true,
+                }"
+                :key="deliveryNote.is_packed"
+                :type="deliveryNote.is_packed ? 'positive' : 'secondary'"
+                :icon="deliveryNote.is_packed ? 'fal fa-check' : undefined"
+                size="xs"
+                :label="deliveryNote.is_packed ? trans('Packed') : trans('Pack')"
+                :disabled="deliveryNote.is_packed"
+            />
         </template>
-
     </Table>
 </template>

--- a/resources/js/Pages/Grp/Org/Dispatching/DeliveryNote.vue
+++ b/resources/js/Pages/Grp/Org/Dispatching/DeliveryNote.vue
@@ -7,7 +7,7 @@
 <script setup lang="ts">
 import { Head, router } from '@inertiajs/vue3'
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faCube, faChair, faHandPaper, faFolder } from '@fal'
+import { faCube, faChair, faHandPaper, faFolder, faBoxCheck } from '@fal'
 import { faArrowRight, faCheck } from '@fas'
 
 import PageHeading from '@/Components/Headings/PageHeading.vue'
@@ -35,7 +35,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { notify } from '@kyvg/vue3-notification'
 
 
-library.add(faFolder, faCube, faChair, faHandPaper, faArrowRight, faCheck)
+library.add(faFolder, faBoxCheck, faCube, faChair, faHandPaper, faArrowRight, faCheck)
 
 const props = defineProps<{
     title: string,

--- a/resources/js/Pages/Grp/Org/Dispatching/DeliveryNote.vue
+++ b/resources/js/Pages/Grp/Org/Dispatching/DeliveryNote.vue
@@ -7,8 +7,8 @@
 <script setup lang="ts">
 import { Head, router } from '@inertiajs/vue3'
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faCube, faChair, faFolder } from '@fal'
-import { faArrowRight } from '@fas'
+import { faCube, faChair, faHandPaper, faFolder } from '@fal'
+import { faArrowRight, faCheck } from '@fas'
 
 import PageHeading from '@/Components/Headings/PageHeading.vue'
 import { capitalize } from "@/Composables/capitalize"
@@ -35,7 +35,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { notify } from '@kyvg/vue3-notification'
 
 
-library.add(faFolder, faCube, faChair, faArrowRight)
+library.add(faFolder, faCube, faChair, faHandPaper, faArrowRight, faCheck)
 
 const props = defineProps<{
     title: string,

--- a/routes/grp/web/models/ordering/order.php
+++ b/routes/grp/web/models/ordering/order.php
@@ -17,6 +17,7 @@ use App\Actions\Dispatching\DeliveryNote\UpdateDeliveryNoteStateToPicked;
 use App\Actions\Dispatching\DeliveryNote\UpdateDeliveryNoteStateToPickerAssigned;
 use App\Actions\Dispatching\DeliveryNote\UpdateDeliveryNoteStateToPicking;
 use App\Actions\Dispatching\DeliveryNote\UpdateDeliveryNoteStateToSettled;
+use App\Actions\Dispatching\Packing\StorePacking;
 use App\Actions\Dispatching\Picking\AssignPackerToPicking;
 use App\Actions\Dispatching\Picking\AssignPickerToPicking;
 use App\Actions\Dispatching\Picking\PickAllItem;
@@ -94,6 +95,7 @@ Route::name('delivery-note.')->prefix('delivery-note/{deliveryNote:id}')->group(
 });
 
 Route::name('delivery-note-item.')->prefix('delivery-note-item/{deliveryNoteItem:id}')->group(function () {
+    Route::post('packing', StorePacking::class)->name('packing.store')->withoutScopedBindings();
     Route::post('picking', StorePicking::class)->name('picking.store')->withoutScopedBindings();
     Route::post('picking-all', PickAllItem::class)->name('picking_all.store')->withoutScopedBindings();
     Route::post('not-picking', StoreNotPickPicking::class)->name('not-picking.store')->withoutScopedBindings();


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This migration renames columns `quantity_packed` to `quantity` and `packer_id` to `packer_user_id` in the `packings` table. It also removes the `picking_id` foreign key constraint, and the `picking_id` and `state` columns.

**Key Changes**
- Renames `quantity_packed` column to `quantity`.
- Renames `packer_id` column to `packer_user_id`.
- Removes the `picking_id` foreign key and column.
- Removes the `state` column.

**Recommendations**
Not deployment ready. Provide a justification for removing the `picking_id` and `state` columns, and consider the impact on application logic.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 43 (100%)     |
| Total Changes | 43           |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>