### PR TITLE
fix Webpage

### DIFF
--- a/resources/js/Components/CMS/Webpage/SubDepartement1/SubDepartementIris.vue
+++ b/resources/js/Components/CMS/Webpage/SubDepartement1/SubDepartementIris.vue
@@ -50,7 +50,7 @@ const fallbackPerRow = {
 
 const perRow = computed(() => {
   return (
-    props.fieldValue?.setting?.per_row?.[props.screenType] ||
+    props.fieldValue?.settings?.per_row?.[props.screenType] ||
     fallbackPerRow[props.screenType] ||
     1
   );

--- a/resources/js/Components/CMS/Webpage/SubDepartement1/SubDepartementWorkshop.vue
+++ b/resources/js/Components/CMS/Webpage/SubDepartement1/SubDepartementWorkshop.vue
@@ -72,7 +72,7 @@ const fallbackPerRow = {
 
 const perRow = computed(() => {
   return (
-    props.modelValue?.setting?.per_row?.[props.screenType] ||
+    props.modelValue?.settings?.per_row?.[props.screenType] ||
     fallbackPerRow[props.screenType] ||
     1
   );
@@ -100,7 +100,7 @@ const mergedItems = computed(() => {
   return [...subs, ...collections]
 })
 
-console.log(props)
+
 </script>
 
 <template>

--- a/resources/js/Pages/Grp/Org/Web/WebpageWorkshop.vue
+++ b/resources/js/Pages/Grp/Org/Web/WebpageWorkshop.vue
@@ -419,11 +419,6 @@ const compUsersEditThisPage = computed(() => {
 	return useLiveUsers().liveUsersArray.filter(user => (user.current_page?.route_name === layout.currentRoute && user.current_page?.route_params?.webpage === layout.currentParams?.webpage)).map(user => user.name ?? user.username)
 })
 
-const filterBlock = ref('all')
-
-watch(filterBlock, (newValue) => {
-	sendToIframe({ key: 'isPreviewLoggedIn', value: newValue })
-})
 
 
 </script>


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR fixes a typo in the `per_row` setting access in two components, `SubDepartementIris.vue` and `SubDepartementWorkshop.vue`, changing `setting` to `settings`. It also removes unused code related to filtering blocks and preview login status in `WebpageWorkshop.vue`.

**Key Changes**
- Corrected the property access for `per_row` settings in `SubDepartementIris.vue` and `SubDepartementWorkshop.vue`.
- Removed the unused `filterBlock` variable and its watcher, as well as the associated `sendToIframe` call in `WebpageWorkshop.vue`.

**Recommendations**
Ready for deployment. This PR addresses a minor bug and removes dead code, improving overall code quality.

### 🗂️ Work Breakdown

| Category | Lines Changed |
|---|---|
| Churn | 5 (62.5%) |
| Rework | 3 (37.5%) |
| Total Changes | 8 |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>