### PR TITLE
Settle Retina ORder with balance

### DIFF
--- a/app/Actions/Accounting/OrderPaymentApiPoint/WebHooks/CheckoutComOrderPaymentSuccess.php
+++ b/app/Actions/Accounting/OrderPaymentApiPoint/WebHooks/CheckoutComOrderPaymentSuccess.php
@@ -15,6 +15,7 @@ use App\Actions\IrisAction;
 use App\Actions\Ordering\Order\AttachPaymentToOrder;
 use App\Actions\Ordering\Order\SubmitOrder;
 use App\Actions\Ordering\Order\UpdateOrder;
+use App\Actions\Retina\Dropshipping\Orders\SettleRetinaOrderWithBalance;
 use App\Actions\Retina\Dropshipping\Orders\WithRetinaOrderPlacedRedirection;
 use App\Enums\Accounting\CreditTransaction\CreditTransactionTypeEnum;
 use App\Enums\Accounting\Payment\PaymentStateEnum;
@@ -76,6 +77,11 @@ class CheckoutComOrderPaymentSuccess extends IrisAction
                 'payment_amount' => $payment->amount
             ], strict: false);
 
+            if($order->total_amount > $order->payment_amount && $order->customer->balance > 0) {
+                SettleRetinaOrderWithBalance::run($order);
+            }
+
+            $order->refresh();
             return SubmitOrder::run($order);
         });
 

--- a/app/Actions/Accounting/PaymentAccountShop/UI/GetRetinaPaymentAccountShopCheckoutComData.php
+++ b/app/Actions/Accounting/PaymentAccountShop/UI/GetRetinaPaymentAccountShopCheckoutComData.php
@@ -31,9 +31,25 @@ class GetRetinaPaymentAccountShopCheckoutComData
 
         $paymentSessionClient = $checkoutApi->getPaymentSessionsClient();
 
+        $toPay = (float) max($order->total_amount, 0.0);
+        $balance = (float) $order->customer->balance;
+
+        $decimalPart = $toPay - floor($toPay);
+
+        $payFloatWithBalance = min($decimalPart, $balance);
+
+        $remainingBalance = $balance - $payFloatWithBalance;
+        $payIntWithBalance = min(floor($toPay), floor($remainingBalance));
+
+        $toPayByBalance = round($payFloatWithBalance + $payIntWithBalance, 2);
+        $toPayByOther = round($toPay - $toPayByBalance, 2);
+
+        if($toPayByOther == 0) {
+            abort(404);
+        }
 
         $paymentSessionRequest            = new PaymentSessionsRequest();
-        $paymentSessionRequest->amount    = (int)$order->total_amount * 100;
+        $paymentSessionRequest->amount    = (int)$toPayByOther * 100;
         $paymentSessionRequest->currency  = $order->currency->code;
         $paymentSessionRequest->reference = $order->reference;
 

--- a/app/Actions/Retina/Dropshipping/Checkout/UI/ShowRetinaDropshippingCheckout.php
+++ b/app/Actions/Retina/Dropshipping/Checkout/UI/ShowRetinaDropshippingCheckout.php
@@ -91,10 +91,18 @@ class ShowRetinaDropshippingCheckout extends RetinaAction
         $order = Arr::get($checkoutData, 'order');
 
 
-        $toPay          = (float) ($order->total_amount > 0 ? $order->total_amount : 0.0);
-        $toPayByBalance = min((float) $this->customer->balance, $toPay);
-        $toPayByOther   = max($toPay - $toPayByBalance, 0.0);
+        $toPay = (float) max($order->total_amount, 0.0);
+        $balance = (float) $this->customer->balance;
 
+        $decimalPart = $toPay - floor($toPay);
+
+        $payFloatWithBalance = min($decimalPart, $balance);
+
+        $remainingBalance = $balance - $payFloatWithBalance;
+        $payIntWithBalance = min(floor($toPay), floor($remainingBalance));
+
+        $toPayByBalance = round($payFloatWithBalance + $payIntWithBalance, 2);
+        $toPayByOther = round($toPay - $toPayByBalance, 2);
 
         return Inertia::render(
             'Dropshipping/RetinaDropshippingCheckout',

--- a/app/Actions/Retina/Dropshipping/Orders/SettleRetinaOrderWithBalance.php
+++ b/app/Actions/Retina/Dropshipping/Orders/SettleRetinaOrderWithBalance.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ * author Arya Permana - Kirin
+ * created on 02-07-2025-15h-20m
+ * github: https://github.com/KirinZero0
+ * copyright 2025
+*/
+
+namespace App\Actions\Retina\Dropshipping\Orders;
+
+use App\Actions\Accounting\CreditTransaction\StoreCreditTransaction;
+use App\Actions\Accounting\Payment\StorePayment;
+use App\Actions\Ordering\Order\AttachPaymentToOrder;
+use App\Actions\Ordering\Order\SubmitOrder;
+use App\Actions\Ordering\Order\UpdateOrder;
+use App\Actions\RetinaAction;
+use App\Enums\Accounting\CreditTransaction\CreditTransactionTypeEnum;
+use App\Enums\Accounting\Payment\PaymentStateEnum;
+use App\Enums\Accounting\Payment\PaymentStatusEnum;
+use App\Enums\Accounting\Payment\PaymentTypeEnum;
+use App\Models\Accounting\PaymentAccountShop;
+use App\Models\Ordering\Order;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Lorisleiva\Actions\ActionRequest;
+
+class SettleRetinaOrderWithBalance extends RetinaAction
+{
+    /**
+     * @throws \Throwable
+     */
+    public function handle(Order $order): array
+    {
+        $customer = $order->customer;
+
+        $paymentAccountShop = PaymentAccountShop::where('shop_id', $order->shop_id)->where('type', 'account')->where('state', 'active')->first();
+
+        if (!$paymentAccountShop) {
+            return [
+                'success' => false,
+                'reason'  => 'No payment account found',
+                'status'  => PaymentStatusEnum::SUCCESS,
+                'state'   => PaymentStateEnum::COMPLETED,
+                'type'    => PaymentTypeEnum::PAYMENT
+
+            ];
+        }
+
+        $amountToPay = $order->total_amount - $order->payment_amount;
+        $amount = 0;
+        if($customer->balance < $amountToPay) {
+            $amount = $customer->balance;
+        } else {
+            $amount = $amountToPay;
+        }
+
+        $paymentData = [
+            'reference'               => 'cu-'.$customer->id.'-bal-'.Str::random(10),
+            'amount'                  => $amount,
+            'status'                  => 'in_process',
+            'payment_account_shop_id' => $paymentAccountShop->id
+        ];
+
+        $order = DB::transaction(function () use ($order, $customer, $paymentAccountShop, $paymentData, $amount) {
+            $payment = StorePayment::make()->action($customer, $paymentAccountShop->paymentAccount, $paymentData);
+
+            AttachPaymentToOrder::make()->action($order, $payment, [
+                'amount' => $amount
+            ]);
+
+            $order = UpdateOrder::make()->action(order: $order, modelData:[
+                'payment_amount' => $order->payments->sum('amount')
+            ], strict: false);
+
+            $creditTransactionData = [
+                'amount'     => -$amount,
+                'type'       => CreditTransactionTypeEnum::PAYMENT,
+                'payment_id' => $payment->id,
+            ];
+            StoreCreditTransaction::make()->action($customer, $creditTransactionData);
+
+            return $order;
+        });
+
+        return [
+            'success' => true,
+            'reason'  => 'Order paid successfully',
+            'order'   => $order,
+        ];
+    }
+}


### PR DESCRIPTION
 
 
 **PR Summary by Typo**
------------

**Overview:**
This PR introduces the ability to settle Retina orders using the customer's existing balance. It modifies the checkout process to account for balance payments and adds a new action to handle balance settlements.

**Key Changes:**
- Added `SettleRetinaOrderWithBalance` action to handle order settlement using customer balance.
- Modified `CheckoutComOrderPaymentSuccess` to trigger balance settlement if the order total exceeds the paid amount and the customer has a positive balance.
- Updated `GetRetinaPaymentAccountShopCheckoutComData` and `ShowRetinaDropshippingCheckout` to calculate and display the amounts to be paid by balance and other payment methods.
- Implemented logic to prioritize using the customer's balance for the decimal portion of the order total.

**Recommendations:**
Not deployment ready. Add input validation and comprehensive logging to the `SettleRetinaOrderWithBalance` action to ensure robustness and facilitate debugging.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 122 (97%)      |
| Churn       | 1 (1%)        |
| Rework      | 3 (2%)        |
| Total Changes | 126           |

 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>