### PR TITLE
unifnishged pay order with saved mit cards

### DIFF
--- a/app/Actions/Retina/Dropshipping/Orders/PayRetinaOrderWithSavedCards.php
+++ b/app/Actions/Retina/Dropshipping/Orders/PayRetinaOrderWithSavedCards.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * author Arya Permana - Kirin
+ * created on 02-07-2025-17h-39m
+ * github: https://github.com/KirinZero0
+ * copyright 2025
+*/
+
+namespace App\Actions\Retina\Dropshipping\Orders;
+
+use App\Actions\Accounting\CreditTransaction\StoreCreditTransaction;
+use App\Actions\Accounting\Payment\StorePayment;
+use App\Actions\Ordering\Order\AttachPaymentToOrder;
+use App\Actions\Ordering\Order\SubmitOrder;
+use App\Actions\Ordering\Order\UpdateOrder;
+use App\Actions\RetinaAction;
+use App\Enums\Accounting\CreditTransaction\CreditTransactionTypeEnum;
+use App\Enums\Accounting\Payment\PaymentStateEnum;
+use App\Enums\Accounting\Payment\PaymentStatusEnum;
+use App\Enums\Accounting\Payment\PaymentTypeEnum;
+use App\Models\Accounting\MitSavedCard;
+use App\Models\Accounting\PaymentAccountShop;
+use App\Models\Ordering\Order;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Lorisleiva\Actions\ActionRequest;
+
+class PayRetinaOrderWithSavedCards extends RetinaAction
+{
+    use WithBasketStateWarning;
+    use WithRetinaOrderPlacedRedirection;
+
+    /**
+     * @throws \Throwable
+     */
+    public function handle(Order $order)
+    {
+        $customer = $order->customer;
+
+        if($customer->balance >= $order->total_amount) {
+            PayRetinaOrderWithBalance::run($order);
+        } else {
+            foreach ($customer->mitSavedCard->sortBy('priority') as $card) {
+                $this->processSavedCard($order,$card);
+            }
+        }
+    }
+
+    public function processSavedCard(Order $order,MitSavedCard $mitSavedCard)
+    {
+        dd('not available yet');
+    }
+
+}


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview:** This PR introduces a new action `PayRetinaOrderWithSavedCards` to handle order payments using saved MIT cards.  The logic prioritizes using the customer's balance first and then iterates through their saved cards.

**Key Changes:**
- Added `PayRetinaOrderWithSavedCards` action to process payments for Retina orders using saved MIT cards.
- Implemented logic to prioritize using customer balance before attempting card payments.
- Includes a placeholder `processSavedCard` function for future implementation of card processing.

**Recommendations:**
Not deployment ready.  The core functionality of processing saved cards is not yet implemented (`processSavedCard` only contains a `dd()`).  Implement the card processing logic to meet production standards.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 54 (100%)     |
| Total Changes | 54           |

 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>