### PR TITLE
INI-675 - fix: resolve missing columns in returns and return_items tables

### DIFF
--- a/database/migrations/2025_12_22_034500_add_platform_id_to_returns_table.php
+++ b/database/migrations/2025_12_22_034500_add_platform_id_to_returns_table.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Author: Oggie Sutrisna
+ * Created: Sun, 22 Dec 2025 11:45:00 Makassar Time
+ * Description: Add platform_id and customer_sales_channel_id to returns table
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('returns', function (Blueprint $table) {
+            $table->unsignedInteger('platform_id')->nullable()->index()->after('customer_client_id');
+            $table->foreign('platform_id')->references('id')->on('platforms')->nullOnDelete();
+            $table->unsignedBigInteger('customer_sales_channel_id')->nullable()->index()->after('platform_id');
+            $table->foreign('customer_sales_channel_id')->references('id')->on('customer_sales_channels')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('returns', function (Blueprint $table) {
+            $table->dropForeign(['customer_sales_channel_id']);
+            $table->dropColumn('customer_sales_channel_id');
+            $table->dropForeign(['platform_id']);
+            $table->dropColumn('platform_id');
+        });
+    }
+};


### PR DESCRIPTION
- Add migration for platform_id and customer_sales_channel_id to returns table
- Remove address handling from StoreReturn (address_id, return_country_id don't exist)
- Remove email/phone from StoreReturn (can use customer relationship instead)
- Remove invoice_transaction_id from StoreReturnItem (column doesn't exist)
- Fix updateReturnStats to use correct column name number_items_state_waiting_to_receive
- Remove total_quantity_expected from stats update (column doesn't exist)