### PR TITLE
fix(table): bypass appending prefix dynamically for raw AJAX/JSON req…

### DIFF
--- a/app/InertiaTable/InertiaTable.php
+++ b/app/InertiaTable/InertiaTable.php
@@ -89,6 +89,10 @@ class InertiaTable
 
     public static function updateQueryBuilderParameters(string $name): void
     {
+        if (request()->wantsJson() && !request()->header('X-Inertia')) {
+            return;
+        }
+
         if (empty(static::$defaultQueryBuilderConfig)) {
             static::$defaultQueryBuilderConfig = config('query-builder.parameters');
         }


### PR DESCRIPTION
…uests

This resolves an issue where standalone AJAX instances, such as the Select Infinite dropdown searching against multi-tab table endpoints, failed to process parameters locally. The query-builder prefixing is now bypassed if a request is requesting JSON and lacks the X-Inertia header, allowing standard non-prefixed query parameters (e.g., filter[global]) to correctly route.