### PR TITLE
INI-1589 feat(warehouse): implement delivery note picking split and fix

### DIFF
--- a/app/Actions/Dispatching/Picking/SplitPicking.php
+++ b/app/Actions/Dispatching/Picking/SplitPicking.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Actions\Dispatching\Picking;
+
+use App\Actions\Dispatching\DeliveryNoteItem\CalculateDeliveryNoteItemTotalPicked;
+use App\Actions\Inventory\OrgStockMovement\StoreOrgStockMovement;
+use App\Actions\Helpers\CurrencyExchange\GetCurrencyExchange;
+use App\Actions\OrgAction;
+use App\Enums\Inventory\OrgStockMovement\OrgStockMovementTypeEnum;
+use App\Models\Dispatching\Picking;
+use Illuminate\Support\Facades\DB;
+use Lorisleiva\Actions\ActionRequest;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Lorisleiva\Actions\Concerns\WithAttributes;
+
+class SplitPicking extends OrgAction
+{
+    use AsAction;
+    use WithAttributes;
+
+    public function handle(Picking $picking, float $splitQuantity): Picking
+    {
+        return DB::transaction(function () use ($picking, $splitQuantity): Picking {
+            $originalQty = (float) $picking->quantity;
+            $newOriginalQty = $originalQty - $splitQuantity;
+
+            $picking->update(['quantity' => $newOriginalQty]);
+
+            $originalMovement = $picking->orgStockMovement;
+            $newMovement = null;
+
+            if ($originalMovement !== null) {
+                $originalMovement->update([
+                    'quantity' => -$newOriginalQty,
+                    'org_amount' => -$newOriginalQty * $picking->orgStock->value_in_locations,
+                    'grp_amount' => -$newOriginalQty * $picking->orgStock->value_in_locations * GetCurrencyExchange::run($picking->orgStock->organisation->currency, $picking->orgStock->group->currency),
+                ]);
+
+                $newMovement = StoreOrgStockMovement::run(
+                    $picking->orgStock,
+                    $picking->location,
+                    [
+                        'quantity' => -$splitQuantity,
+                        'type'     => OrgStockMovementTypeEnum::PICKED
+                    ]
+                );
+            }
+
+            $newPicking = $picking->replicate();
+            $newPicking->quantity = $splitQuantity;
+            $newPicking->batch_code_id = null;
+            if ($newMovement !== null) {
+                $newPicking->org_stock_movement_id = $newMovement->id;
+            } else {
+                $newPicking->org_stock_movement_id = null;
+            }
+            $newPicking->save();
+
+            if (app()->environment('production')) {
+                SavePickingInAurora::dispatch($picking);
+                SavePickingInAurora::dispatch($newPicking);
+            }
+
+            CalculateDeliveryNoteItemTotalPicked::make()->action($picking->deliveryNoteItem);
+
+            return $newPicking;
+        });
+    }
+
+    public function asController(Picking $picking, ActionRequest $request): void
+    {
+        $this->initialisationFromShop($picking->shop, $request);
+        $splitQuantity = (float) $request->input('split_quantity');
+
+        if ($splitQuantity <= 0 || $splitQuantity >= (float) $picking->quantity) {
+            abort(422, __('Invalid split quantity'));
+        }
+
+        $this->handle($picking, $splitQuantity);
+    }
+}

--- a/app/Actions/Inventory/OrgStockMovement/DeleteOrgStockMovement.php
+++ b/app/Actions/Inventory/OrgStockMovement/DeleteOrgStockMovement.php
@@ -8,6 +8,7 @@
 
 namespace App\Actions\Inventory\OrgStockMovement;
 
+use App\Actions\Inventory\LocationOrgStock\UpdateLocationOrgStock;
 use App\Actions\OrgAction;
 use App\Actions\Traits\WithActionUpdate;
 use App\Models\Inventory\LocationOrgStock;
@@ -17,33 +18,31 @@ class DeleteOrgStockMovement extends OrgAction
 {
     use WithActionUpdate;
 
-
     public function handle(OrgStockMovement $orgStockMovement): OrgStockMovement
     {
+        $locationOrgStock = LocationOrgStock::where('location_id', $orgStockMovement->location_id)
+            ->where('org_stock_id', $orgStockMovement->org_stock_id)
+            ->first();
 
-        $orgStockMovement->delete();
-        $locationOrgStock = LocationOrgStock::where('location_id', $orgStockMovement->location->id)->where('org_stock_id', $orgStockMovement->orgStock->id)->first();
-
-        if ($locationOrgStock) {
-            // todo do a run stock
+        if ($locationOrgStock !== null) {
+            UpdateLocationOrgStock::run(
+                $locationOrgStock,
+                [
+                    'quantity' => $locationOrgStock->quantity - $orgStockMovement->quantity,
+                ]
+            );
         }
 
+        $orgStockMovement->delete();
+
         return $orgStockMovement;
-
     }
-
-
-
-
 
     public function action(OrgStockMovement $orgStockMovement): OrgStockMovement
     {
-
         $this->asAction       = true;
         $this->initialisation($orgStockMovement->organisation, []);
 
         return $this->handle($orgStockMovement);
     }
-
-
 }

--- a/app/Http/Resources/Dispatching/DeliveryNoteItemsResource.php
+++ b/app/Http/Resources/Dispatching/DeliveryNoteItemsResource.php
@@ -134,6 +134,11 @@ class DeliveryNoteItemsResource extends JsonResource
                             'parameters' => ['picking' => $picking->id],
                             'method'     => 'patch',
                         ],
+                        'split_route'              => [
+                            'name'       => 'grp.models.picking.split',
+                            'parameters' => ['picking' => $picking->id],
+                            'method'     => 'post',
+                        ],
                         'batch_codes_fetch_route'  => [
                             'name'       => 'grp.json.org_stock.batch_codes.index',
                             'parameters' => [

--- a/app/Http/Resources/Dispatching/PickingResource.php
+++ b/app/Http/Resources/Dispatching/PickingResource.php
@@ -70,6 +70,13 @@ class PickingResource extends JsonResource
                 ],
                 'method'     => 'patch'
             ],
+            'split_route'        => [
+                'name'       => 'grp.models.picking.split',
+                'parameters' => [
+                    'picking' => $this->id
+                ],
+                'method'     => 'post'
+            ],
             'undo_picking_route' => [
                 'name'       => 'grp.models.picking.delete',
                 'parameters' => [

--- a/resources/js/Components/Warehouse/DeliveryNotes/TableDeliveryNoteItems.vue
+++ b/resources/js/Components/Warehouse/DeliveryNotes/TableDeliveryNoteItems.vue
@@ -493,6 +493,51 @@ const onSubmitPickingBatchCode = () => {
     )
 }
 
+const isModalSplitPicking = ref(false)
+const selectedPickingForSplit = ref(null)
+const splitQuantity = ref(1)
+const isLoadingSubmitSplitPicking = ref(false)
+
+const onCloseModalSplitPicking = () => {
+    isModalSplitPicking.value = false
+    setTimeout(() => {
+        selectedPickingForSplit.value = null
+        splitQuantity.value = 1
+    }, 300)
+}
+
+const onSubmitSplitPicking = () => {
+    if (!selectedPickingForSplit.value) {
+        return
+    }
+
+    const qty = Number(splitQuantity.value)
+    const maxQty = Number(selectedPickingForSplit.value.quantity_picked)
+    if (isNaN(qty) || qty <= 0 || qty >= maxQty) {
+        notify({ title: trans("Invalid quantity"), text: trans("Quantity to split must be greater than 0 and less than :max", { max: maxQty }), type: "error" })
+        return
+    }
+
+    router.post(
+        route(selectedPickingForSplit.value.split_route.name, selectedPickingForSplit.value.split_route.parameters),
+        { split_quantity: qty },
+        {
+            preserveScroll: true,
+            preserveState: true,
+            onStart: () => { isLoadingSubmitSplitPicking.value = true },
+            onSuccess: () => {
+                notify({ title: trans("Success"), text: trans("Successfully split picking"), type: "success" })
+                onCloseModalSplitPicking()
+            },
+            onError: (errors) => {
+                const errorMsg = get(errors, 'message') || trans("Failed to split picking. Try again")
+                notify({ title: trans("Something went wrong"), text: errorMsg, type: "error" })
+            },
+            onFinish: () => { isLoadingSubmitSplitPicking.value = false },
+        }
+    )
+}
+
 // Section: Undo Quantity Waiting Warehouse
 const isOpenModalUndoWaitingWarehouse = ref(false)
 const selectedItemToUndoWaitingWarehouse = ref(null)
@@ -634,6 +679,17 @@ const onSetItemToUndoWaitingWarehouse = () => {
                         <FontAwesomeIcon icon="fal fa-barcode" class="mr-1" fixed-width aria-hidden="true" />
                         {{ picking.batch_code ?? ctrans('Batch code') }}
                     </button>
+
+                    <!-- Split picking button -->
+                    <button
+                        v-if="picking.show_batch_code_ui && Number(picking.quantity_picked) > 1"
+                        @click="() => (isModalSplitPicking = true, selectedPickingForSplit = picking)"
+                        v-tooltip="ctrans('Split picking')"
+                        class="text-xs px-1.5 py-0.5 rounded border transition-colors border-slate-300 text-slate-400 hover:border-slate-400 hover:text-slate-600 bg-white"
+                    >
+                        <FontAwesomeIcon icon="fal fa-scissors" class="mr-1" fixed-width aria-hidden="true" />
+                        {{ ctrans('Split') }}
+                    </button>
                 </div>
             </div>
             <div v-else class="text-gray-400 italic text-sm">No items picked yet</div>
@@ -754,6 +810,17 @@ const onSetItemToUndoWaitingWarehouse = () => {
                         >
                             <FontAwesomeIcon icon="fal fa-barcode" class="mr-1" fixed-width aria-hidden="true" />
                             {{ picking.batch_code ?? ctrans('Batch code') }}
+                        </button>
+
+                        <!-- Split picking button -->
+                        <button
+                            v-if="picking.show_batch_code_ui && Number(picking.quantity_picked) > 1"
+                            @click="() => (isModalSplitPicking = true, selectedPickingForSplit = picking)"
+                            v-tooltip="ctrans('Split picking')"
+                            class="text-xs px-1.5 py-0.5 rounded border transition-colors border-slate-300 text-slate-400 hover:border-slate-400 hover:text-slate-600 bg-white ml-2"
+                        >
+                            <FontAwesomeIcon icon="fal fa-scissors" class="mr-1" fixed-width aria-hidden="true" />
+                            {{ ctrans('Split') }}
                         </button>
 
                     </div>
@@ -1482,6 +1549,54 @@ const onSetItemToUndoWaitingWarehouse = () => {
                     @click="onSubmitPickingBatchCode"
                     full
                     :label="trans('Save')"
+                />
+            </div>
+        </div>
+    </Modal>
+
+    <Modal :isOpen="isModalSplitPicking" @onClose="onCloseModalSplitPicking" width="w-full max-w-lg">
+        <div class="text-center mb-4">
+            <div class="font-semibold text-2xl">{{ trans('Split Picking') }}</div>
+            <div class="opacity-80 italic text-sm">
+                <span v-if="selectedPickingForSplit?.location_code">{{ ctrans('Location: :loc', { loc: selectedPickingForSplit.location_code }) }} || </span>
+                <span>{{ ctrans("Total Quantity") }}: {{ selectedPickingForSplit?.quantity_picked }}</span>
+            </div>
+        </div>
+
+        <div class="flex flex-col gap-4">
+            <div class="w-full">
+                <label class="block text-sm font-medium mb-2">{{ trans("Quantity to split off") }}:</label>
+                <PureInput
+                    type="number"
+                    v-model="splitQuantity"
+                    :min="0.001"
+                    :max="selectedPickingForSplit ? selectedPickingForSplit.quantity_picked - 0.001 : 1"
+                    step="0.001"
+                    :disabled="isLoadingSubmitSplitPicking"
+                    required
+                />
+                <span class="text-xs text-slate-400 mt-1 block">
+                    {{ ctrans("Enter a quantity greater than 0 and less than :max", { max: selectedPickingForSplit?.quantity_picked }) }}
+                </span>
+            </div>
+
+            <div class="w-full flex gap-4 mt-4">
+                <Button
+                    type="negative"
+                    size="md"
+                    :disabled="isLoadingSubmitSplitPicking"
+                    icon="far fa-arrow-left"
+                    @click="onCloseModalSplitPicking"
+                    :label="trans('Cancel')"
+                />
+                <Button
+                    type="primary"
+                    size="md"
+                    :loading="isLoadingSubmitSplitPicking"
+                    icon="fad fa-scissors"
+                    @click="onSubmitSplitPicking"
+                    full
+                    :label="trans('Split')"
                 />
             </div>
         </div>

--- a/routes/grp/web/models/ordering/order.php
+++ b/routes/grp/web/models/ordering/order.php
@@ -14,6 +14,7 @@ use App\Actions\Dispatching\Picking\AssignPackerToPicking;
 use App\Actions\Dispatching\Picking\AssignPickerToPicking;
 use App\Actions\Dispatching\Picking\DeletePicking;
 use App\Actions\Dispatching\Picking\UpdatePicking;
+use App\Actions\Dispatching\Picking\SplitPicking;
 use App\Actions\GoodsIn\Return\StoreReturn;
 use App\Actions\Helpers\Media\AttachAttachmentToModel;
 use App\Actions\Helpers\Media\DetachAttachmentFromModel;
@@ -108,6 +109,7 @@ Route::name('order.')->prefix('order/{order:id}')->group(function () {
 Route::name('picking.')->prefix('picking/{picking:id}')->group(function () {
     Route::patch('update', UpdatePicking::class)->name('update');
     Route::delete('delete', DeletePicking::class)->name('delete');
+    Route::post('split', SplitPicking::class)->name('split');
 
     Route::name('assign.')->prefix('assign')->group(function () {
         Route::patch('picker', AssignPickerToPicking::class)->name('picker');


### PR DESCRIPTION
This PR implements a new feature allowing warehouse users to split delivery note picking items into separate records for flexible batch code assignment, and fixes the stock movement deletion logic to correctly update location inventory.