### PR TITLE
🩹 fix(crm): cap customer journey timeline at 200 most recent events

### DIFF
--- a/app/Actions/CRM/Customer/UI/GetCustomerJourney.php
+++ b/app/Actions/CRM/Customer/UI/GetCustomerJourney.php
@@ -19,11 +19,17 @@ class GetCustomerJourney
 {
     use AsObject;
 
+    // ponytail: flat cap on rendered events; paginate the timeline if anyone needs to walk further back
+    public const MAX_EVENTS = 200;
+
     /**
      * Builds the read-only marketing journey of a customer: every recorded traffic source touch and
      * every issued invoice, interleaved on a single time axis, plus the resulting attribution split.
      *
-     * @return array{events: array<int, array<string, mixed>>, attribution: array<int, array{label: string, share: float, campaign: string|null}>, attribution_window_days: int, currency_code: string}
+     * Only the most recent self::MAX_EVENTS events are returned; `omitted_events` reports how many
+     * older ones were dropped so the timeline never silently presents itself as complete.
+     *
+     * @return array{events: array<int, array<string, mixed>>, omitted_events: int, attribution: array<int, array{label: string, share: float, campaign: string|null}>, attribution_window_days: int, currency_code: string}
      */
     public function handle(Customer $customer): array
     {
@@ -75,8 +81,11 @@ class GetCustomerJourney
 
         usort($events, fn (array $a, array $b) => [$a['datetime'], $a['type']] <=> [$b['datetime'], $b['type']]);
 
+        $totalEvents = count($events);
+
         return [
-            'events'                  => $events,
+            'events'                  => array_slice($events, -self::MAX_EVENTS),
+            'omitted_events'          => max(0, $totalEvents - self::MAX_EVENTS),
             'attribution'             => $this->attribution($customer, $labels),
             'attribution_window_days' => $windowDays,
             'currency_code'           => $customer->shop->currency->code,

--- a/resources/js/Components/Showcases/Grp/CustomerJourney.vue
+++ b/resources/js/Components/Showcases/Grp/CustomerJourney.vue
@@ -31,6 +31,7 @@ interface JourneyEvent {
 const props = defineProps<{
     data?: {
         events: JourneyEvent[]
+        omitted_events: number
         attribution: { label: string, share: number, campaign: string | null }[]
         attribution_window_days: number
         currency_code: string
@@ -60,7 +61,11 @@ const locale = useLocaleStore()
             {{ trans('No marketing touches or invoices recorded for this customer') }}
         </div>
 
-        <ol v-else class="relative border-l border-gray-200 ml-3">
+        <div v-if="data.omitted_events > 0" class="mb-4 text-xs text-gray-400">
+            {{ trans('Showing the most recent :shown events, :omitted older ones are not listed', { shown: data.events.length, omitted: data.omitted_events }) }}
+        </div>
+
+        <ol v-if="data.events.length" class="relative border-l border-gray-200 ml-3">
             <li v-for="event in data.events" :key="event.id" class="mb-6 ml-6">
                 <span
                     class="absolute -left-3 flex h-6 w-6 items-center justify-center rounded-full ring-4 ring-white"

--- a/tests/Feature/CRM/CustomerJourneyTest.php
+++ b/tests/Feature/CRM/CustomerJourneyTest.php
@@ -94,6 +94,31 @@ it('flags a touch that falls outside the attribution window of the following pur
         ->and($touches[1]['in_window'])->toBeTrue();
 });
 
+it('caps the timeline at the most recent events and reports how many were omitted', function () {
+    $cap    = GetCustomerJourney::MAX_EVENTS;
+    $extra  = 5;
+    $oldest = now()->subDays($cap + $extra + 1);
+
+    $touches = collect(range(0, $cap + $extra - 1))
+        ->map(fn (int $offset) => $oldest->copy()->addDays($offset)->timestamp.'a')
+        ->implode('|');
+
+    $customer = journeyCustomer($this->shop, $touches);
+
+    $journey = GetCustomerJourney::run($customer->refresh());
+
+    expect($journey['events'])->toHaveCount($cap)
+        ->and($journey['omitted_events'])->toBe($extra)
+        ->and($journey['events'][0]['datetime'])->toBe($oldest->copy()->addDays($extra)->toIso8601String())
+        ->and($journey['events'][$cap - 1]['datetime'])->toBe($oldest->copy()->addDays($cap + $extra - 1)->toIso8601String());
+});
+
+it('reports no omitted events for a short journey', function () {
+    $customer = journeyCustomer($this->shop, now()->subDays(2)->timestamp.'a');
+
+    expect(GetCustomerJourney::run($customer->refresh())['omitted_events'])->toBe(0);
+});
+
 it('honours the per shop attribution window override', function () {
     $touch = now()->subDays(30)->timestamp;
 

--- a/tests/Feature/MarketingTest.php
+++ b/tests/Feature/MarketingTest.php
@@ -1037,6 +1037,31 @@ describe('customer journey', function () {
         expect($journey['attribution_window_days'])->toBe(7)
             ->and($journey['events'][0]['in_window'])->toBeFalse();
     });
+
+    it('caps the timeline at the most recent events and reports how many were omitted', function () {
+        $cap    = GetCustomerJourney::MAX_EVENTS;
+        $extra  = 5;
+        $oldest = now()->subDays($cap + $extra + 1);
+
+        $touches = collect(range(0, $cap + $extra - 1))
+            ->map(fn (int $offset) => $oldest->copy()->addDays($offset)->timestamp.'a')
+            ->implode('|');
+
+        $customer = journeyCustomer($this->shop, $touches);
+
+        $journey = GetCustomerJourney::run($customer->refresh());
+
+        expect($journey['events'])->toHaveCount($cap)
+            ->and($journey['omitted_events'])->toBe($extra)
+            ->and($journey['events'][0]['datetime'])->toBe($oldest->copy()->addDays($extra)->toIso8601String())
+            ->and($journey['events'][$cap - 1]['datetime'])->toBe($oldest->copy()->addDays($cap + $extra - 1)->toIso8601String());
+    });
+
+    it('reports no omitted events for a short journey', function () {
+        $customer = journeyCustomer($this->shop, now()->subDays(2)->timestamp.'a');
+
+        expect(GetCustomerJourney::run($customer->refresh())['omitted_events'])->toBe(0);
+    });
 });
 
 describe('referral traffic sources', function () {


### PR DESCRIPTION
Follow-up to #2538. `GetCustomerJourney` returned every touch and invoice with no limit — a real customer on the dev database produced **8,412 events (~1.2MB of Inertia props and 8,412 DOM rows)**.

- Caps output at the 200 most recent events (`GetCustomerJourney::MAX_EVENTS`), keeping chronological order.
- Adds `omitted_events` to the payload and a line in the UI ("Showing the most recent 200 events, 8212 older ones are not listed") so a truncated timeline never reads as complete.

Measured on customer `215814-ds`: 8412 events → 200 events, 8212 omitted, payload down to ~23KB.

Tests: two cases added to `tests/Feature/CRM/CustomerJourneyTest.php` (cap keeps the newest events and counts omissions; short journeys report 0). 6 passed.