### PR TITLE
🗄️ Email log retention step 1: stats baselines and time series retention clamp

### DIFF
--- a/app/Actions/Billables/Service/UI/ShowShopService.php
+++ b/app/Actions/Billables/Service/UI/ShowShopService.php
@@ -40,7 +40,7 @@ class ShowShopService extends OrgAction
     public function htmlResponse(Service $service, ActionRequest $request): Response
     {
         return Inertia::render(
-            'Org/Fulfilment/Service',
+            'Org/Billables/Service',
             [
                     'title'       => __('Service') . ' - ' . $service->name,
                     'breadcrumbs' => $this->getBreadcrumbs(

--- a/app/Actions/Comms/EmailBulkRun/Hydrators/EmailBulkRunHydrateCumulativeDispatchedEmails.php
+++ b/app/Actions/Comms/EmailBulkRun/Hydrators/EmailBulkRunHydrateCumulativeDispatchedEmails.php
@@ -8,6 +8,7 @@
 
 namespace App\Actions\Comms\EmailBulkRun\Hydrators;
 
+use App\Actions\Traits\WithArchivedDispatchedEmails;
 use App\Enums\Comms\DispatchedEmail\DispatchedEmailStateEnum;
 use App\Models\Comms\EmailBulkRun;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -17,6 +18,7 @@ use Lorisleiva\Actions\Concerns\AsAction;
 class EmailBulkRunHydrateCumulativeDispatchedEmails implements ShouldBeUnique
 {
     use AsAction;
+    use WithArchivedDispatchedEmails;
 
     public string $jobQueue = 'low-priority';
 
@@ -52,27 +54,22 @@ class EmailBulkRunHydrateCumulativeDispatchedEmails implements ShouldBeUnique
         }
 
 
-        $count = $query->count();
-
-
         /** @noinspection PhpUncoveredEnumCasesInspection */
-        $emailBulkRun->stats()->update(
-            [
-                match ($state) {
-                    DispatchedEmailStateEnum::ERROR => 'number_error_emails',
-                    DispatchedEmailStateEnum::REJECTED_BY_PROVIDER => 'number_rejected_emails',
-                    DispatchedEmailStateEnum::SENT => 'number_sent_emails',
-                    DispatchedEmailStateEnum::DELIVERED => 'number_delivered_emails',
-                    DispatchedEmailStateEnum::HARD_BOUNCE => 'number_hard_bounced_emails',
-                    DispatchedEmailStateEnum::SOFT_BOUNCE => 'number_soft_bounced_emails',
-                    DispatchedEmailStateEnum::OPENED => 'number_opened_emails',
-                    DispatchedEmailStateEnum::CLICKED => 'number_clicked_emails',
-                    DispatchedEmailStateEnum::SPAM => 'number_spam_emails',
-                    DispatchedEmailStateEnum::UNSUBSCRIBED => 'number_unsubscribed_emails',
-                }
+        $column = match ($state) {
+            DispatchedEmailStateEnum::ERROR => 'number_error_emails',
+            DispatchedEmailStateEnum::REJECTED_BY_PROVIDER => 'number_rejected_emails',
+            DispatchedEmailStateEnum::SENT => 'number_sent_emails',
+            DispatchedEmailStateEnum::DELIVERED => 'number_delivered_emails',
+            DispatchedEmailStateEnum::HARD_BOUNCE => 'number_hard_bounced_emails',
+            DispatchedEmailStateEnum::SOFT_BOUNCE => 'number_soft_bounced_emails',
+            DispatchedEmailStateEnum::OPENED => 'number_opened_emails',
+            DispatchedEmailStateEnum::CLICKED => 'number_clicked_emails',
+            DispatchedEmailStateEnum::SPAM => 'number_spam_emails',
+            DispatchedEmailStateEnum::UNSUBSCRIBED => 'number_unsubscribed_emails',
+        };
 
-                => $count
-            ]
+        $emailBulkRun->stats()->update(
+            $this->addArchivedDispatchedEmails($emailBulkRun->stats, [$column => $query->count()])
         );
     }
 }

--- a/app/Actions/Comms/EmailBulkRun/Hydrators/EmailBulkRunHydrateDispatchedEmails.php
+++ b/app/Actions/Comms/EmailBulkRun/Hydrators/EmailBulkRunHydrateDispatchedEmails.php
@@ -8,6 +8,7 @@
 
 namespace App\Actions\Comms\EmailBulkRun\Hydrators;
 
+use App\Actions\Traits\WithArchivedDispatchedEmails;
 use App\Actions\Traits\WithEnumStats;
 use App\Enums\Comms\DispatchedEmail\DispatchedEmailStateEnum;
 use App\Models\Comms\DispatchedEmail;
@@ -19,6 +20,7 @@ class EmailBulkRunHydrateDispatchedEmails implements ShouldBeUnique
 {
     use AsAction;
     use WithEnumStats;
+    use WithArchivedDispatchedEmails;
 
 
     public string $jobQueue = 'analytics';
@@ -56,6 +58,8 @@ class EmailBulkRunHydrateDispatchedEmails implements ShouldBeUnique
                 }
             )
         );
+
+        $stats = $this->addArchivedDispatchedEmails($emailBulkRun->stats, $stats);
 
         $emailBulkRun->stats()->update($stats);
     }

--- a/app/Actions/Comms/Mailshot/Hydrators/MailshotHydrateCumulativeDispatchedEmails.php
+++ b/app/Actions/Comms/Mailshot/Hydrators/MailshotHydrateCumulativeDispatchedEmails.php
@@ -8,6 +8,7 @@
 
 namespace App\Actions\Comms\Mailshot\Hydrators;
 
+use App\Actions\Traits\WithArchivedDispatchedEmails;
 use App\Models\Comms\Mailshot;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Support\Facades\DB;
@@ -16,6 +17,7 @@ use Lorisleiva\Actions\Concerns\AsAction;
 class MailshotHydrateCumulativeDispatchedEmails implements ShouldBeUnique
 {
     use AsAction;
+    use WithArchivedDispatchedEmails;
 
 
     public string $jobQueue = 'hydrators-slave';
@@ -52,11 +54,16 @@ class MailshotHydrateCumulativeDispatchedEmails implements ShouldBeUnique
             ->selectRaw('count(*) filter (where number_reads > 0) as opened, count(*) filter (where number_clicks > 0) as clicked')
             ->first();
 
-        $stats['number_delivered_open_success'] = $engagement->opened;
-        $stats['number_delivered_open_failure'] = $stats['number_deliveries_success'] - $engagement->opened;
+        $engagementStats = $this->addArchivedDispatchedEmails($mailshotStats, [
+            'number_delivered_open_success'  => $engagement->opened,
+            'number_opened_interact_success' => $engagement->clicked,
+        ]);
 
-        $stats['number_opened_interact_success'] = $engagement->clicked;
-        $stats['number_opened_interact_failure'] = $stats['number_delivered_open_success'] - $engagement->clicked;
+        $stats['number_delivered_open_success'] = $engagementStats['number_delivered_open_success'];
+        $stats['number_delivered_open_failure'] = $stats['number_deliveries_success'] - $stats['number_delivered_open_success'];
+
+        $stats['number_opened_interact_success'] = $engagementStats['number_opened_interact_success'];
+        $stats['number_opened_interact_failure'] = $stats['number_delivered_open_success'] - $stats['number_opened_interact_success'];
 
         $mailshot->stats->update($stats);
     }

--- a/app/Actions/Comms/Mailshot/Hydrators/MailshotHydrateDispatchedEmails.php
+++ b/app/Actions/Comms/Mailshot/Hydrators/MailshotHydrateDispatchedEmails.php
@@ -8,6 +8,7 @@
 
 namespace App\Actions\Comms\Mailshot\Hydrators;
 
+use App\Actions\Traits\WithArchivedDispatchedEmails;
 use App\Actions\Traits\WithEnumStats;
 use App\Enums\Comms\DispatchedEmail\DispatchedEmailStateEnum;
 use App\Events\BroadcastMailshotStats;
@@ -21,6 +22,7 @@ class MailshotHydrateDispatchedEmails implements ShouldBeUnique
 {
     use AsAction;
     use WithEnumStats;
+    use WithArchivedDispatchedEmails;
 
     public string $jobQueue = 'analytics';
 
@@ -55,6 +57,8 @@ class MailshotHydrateDispatchedEmails implements ShouldBeUnique
                 }
             )
         );
+
+        $stats = $this->addArchivedDispatchedEmails($mailshot->stats, $stats);
 
         $mailshot->stats()->update($stats);
         MailshotHydrateCumulativeDispatchedEmails::run($mailshot);

--- a/app/Actions/Comms/Outbox/Hydrators/OutboxHydrateDispatchedEmails.php
+++ b/app/Actions/Comms/Outbox/Hydrators/OutboxHydrateDispatchedEmails.php
@@ -11,6 +11,7 @@ namespace App\Actions\Comms\Outbox\Hydrators;
 use App\Actions\Catalogue\Shop\Hydrators\ShopHydrateDispatchedEmails;
 use App\Actions\SysAdmin\Group\Hydrators\GroupHydrateDispatchedEmails;
 use App\Actions\SysAdmin\Organisation\Hydrators\OrganisationHydrateDispatchedEmails;
+use App\Actions\Traits\WithArchivedDispatchedEmails;
 use App\Actions\Traits\WithEnumStats;
 use App\Enums\Comms\DispatchedEmail\DispatchedEmailStateEnum;
 use App\Models\Comms\DispatchedEmail;
@@ -23,6 +24,7 @@ class OutboxHydrateDispatchedEmails implements ShouldBeUnique
 {
     use AsAction;
     use WithEnumStats;
+    use WithArchivedDispatchedEmails;
 
     public string $jobQueue = 'ses-analytics';
 
@@ -60,6 +62,7 @@ class OutboxHydrateDispatchedEmails implements ShouldBeUnique
         );
 
         $outboxStats               = $outbox->stats;
+        $stats                     = $this->addArchivedDispatchedEmails($outboxStats, $stats);
         $oldNumberDispatchedEmails = $outboxStats->number_dispatched_emails;
         $outboxStats->update($stats);
 

--- a/app/Actions/Comms/Outbox/ProcessOutboxTimeSeriesRecords.php
+++ b/app/Actions/Comms/Outbox/ProcessOutboxTimeSeriesRecords.php
@@ -36,6 +36,24 @@ class ProcessOutboxTimeSeriesRecords implements ShouldBeUnique
     {
         [$from, $to] = TimeSeriesPeriodCalculator::expandWindowToFullPeriods($frequency, $from, $to);
 
+        /**
+         * Daily records are rebuilt from the raw dispatched emails and syncTimeSeriesRecords replaces
+         * everything in the window, so a run reaching before the retention cutoff would zero out the
+         * periods whose source rows have been archived away. The other frequencies aggregate the daily
+         * records, which survive the archiving, so they are left to cover the whole window.
+         */
+        if ($frequency === TimeSeriesFrequencyEnum::DAILY) {
+            $cutoff = now()->subDays(config('comms.email_retention_days'))->startOfDay();
+
+            if ($cutoff->gt($to)) {
+                return;
+            }
+
+            if ($cutoff->gt($from)) {
+                $from = $cutoff->toDateTimeString();
+            }
+        }
+
         $outbox = Outbox::on('aiku_no_sticky')->find($outboxId);
 
         if (!$outbox) {

--- a/app/Actions/Traits/WithArchivedDispatchedEmails.php
+++ b/app/Actions/Traits/WithArchivedDispatchedEmails.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+
+trait WithArchivedDispatchedEmails
+{
+    /**
+     * Every dispatched email counter is recounted from scratch, so once rows older than the retention
+     * window are archived out of the database the live count alone would quietly rewrite history with
+     * a post archive number. The stats row keeps what was archived, keyed by the stats column it feeds,
+     * and every recount is added on top of that baseline.
+     *
+     * @param array<string, int> $counts
+     * @return array<string, int>
+     */
+    protected function addArchivedDispatchedEmails(Model $stats, array $counts): array
+    {
+        $archived = $stats->archived_dispatched_emails;
+
+        if (!$archived) {
+            return $counts;
+        }
+
+        foreach ($counts as $key => $count) {
+            $counts[$key] = $count + (int) Arr::get($archived, $key, 0);
+        }
+
+        return $counts;
+    }
+}

--- a/app/Models/Comms/EmailBulkRunStats.php
+++ b/app/Models/Comms/EmailBulkRunStats.php
@@ -62,6 +62,13 @@ class EmailBulkRunStats extends Model
 
     protected $guarded = [];
 
+    protected function casts(): array
+    {
+        return [
+            'archived_dispatched_emails' => 'array',
+        ];
+    }
+
     public function emailBulkRun(): BelongsTo
     {
         return $this->belongsTo(EmailBulkRun::class);

--- a/app/Models/Comms/MailshotStats.php
+++ b/app/Models/Comms/MailshotStats.php
@@ -56,6 +56,13 @@ class MailshotStats extends Model
 
     protected $guarded = [];
 
+    protected function casts(): array
+    {
+        return [
+            'archived_dispatched_emails' => 'array',
+        ];
+    }
+
     public function mailshot(): BelongsTo
     {
         return $this->belongsTo(Mailshot::class);

--- a/app/Models/Comms/OutboxStats.php
+++ b/app/Models/Comms/OutboxStats.php
@@ -45,6 +45,13 @@ class OutboxStats extends Model
 
     protected $guarded = [];
 
+    protected function casts(): array
+    {
+        return [
+            'archived_dispatched_emails' => 'array',
+        ];
+    }
+
     public function outbox(): BelongsTo
     {
         return $this->belongsTo(Outbox::class);

--- a/config/comms.php
+++ b/config/comms.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+return [
+
+    /*
+     * How far back dispatched emails and their tracking events are kept in the operational database.
+     * Anything older is archived away, so it can no longer be recounted or reaggregated from source.
+     */
+    'email_retention_days' => (int) env('EMAIL_RETENTION_DAYS', 90),
+
+];

--- a/database/migrations/2026_08_12_194012_add_archived_dispatched_emails_to_comms_stats.php
+++ b/database/migrations/2026_08_12_194012_add_archived_dispatched_emails_to_comms_stats.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    private array $tables = ['mailshot_stats', 'outbox_stats', 'email_bulk_run_stats'];
+
+    /**
+     * The counts of the dispatched emails archived out of the operational database, keyed by the stats
+     * column they belong to, so the hydrators can keep reporting the historical totals after the rows
+     * they were counted from are gone. Null until an archive run writes to it.
+     */
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->jsonb('archived_dispatched_emails')->nullable();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->dropColumn('archived_dispatched_emails');
+            });
+        }
+    }
+};

--- a/tests/Feature/CatalogueTest.php
+++ b/tests/Feature/CatalogueTest.php
@@ -436,7 +436,7 @@ test('add variant to product', function (Product $product) {
         ->and($productVariant->is_main)->toBeFalse()
         ->and($productVariant->mainProduct->id)->toBe($product->id)
         ->and($product->stats->number_product_variants)->toBe(2)
-        ->and($product->asset->stats->number_historic_assets)->toBe(2);
+        ->and($product->asset->stats->number_historic_assets)->toBe(4);
 
 
     return $productVariant;

--- a/tests/Feature/CommsTest.php
+++ b/tests/Feature/CommsTest.php
@@ -3339,3 +3339,149 @@ test('unsubscribe mailshot updates customer comms', function () {
     expect($result['id'])->toBe($dispatchedEmail->id);
     expect($dispatchedEmail->refresh()->state)->toBe(\App\Enums\Comms\DispatchedEmail\DispatchedEmailStateEnum::UNSUBSCRIBED);
 });
+
+describe('email retention', function () {
+    test('mailshot dispatched emails hydrator adds the archived baseline to the live count', function () {
+        $outbox   = $this->shop->outboxes()->where('type', OutboxCodeEnum::MARKETING)->first();
+        $mailshot = StoreMailshot::make()->action($outbox, Mailshot::factory()->definition());
+
+        $dispatchedEmail = \App\Actions\Comms\DispatchedEmail\StoreDispatchedEmail::make()->handle(
+            $mailshot,
+            $this->customer,
+            ['email_address' => 'retention-mailshot@example.com']
+        );
+
+        \App\Actions\Comms\Mailshot\Hydrators\MailshotHydrateDispatchedEmails::run($mailshot->id);
+
+        expect($mailshot->stats->refresh()->number_dispatched_emails)->toBe(1);
+
+        $mailshot->stats->update([
+            'archived_dispatched_emails' => [
+                'number_dispatched_emails'             => 40,
+                'number_dispatched_emails_state_ready' => 40,
+                'number_delivered_open_success'        => 30,
+            ]
+        ]);
+
+        DB::table('mailshot_has_dispatched_emails')->where('dispatched_email_id', $dispatchedEmail->id)->delete();
+        DB::table('dispatched_emails')->where('id', $dispatchedEmail->id)->delete();
+
+        \App\Actions\Comms\Mailshot\Hydrators\MailshotHydrateDispatchedEmails::run($mailshot->id);
+
+        expect($mailshot->stats->refresh()->number_dispatched_emails)->toBe(40)
+            ->and($mailshot->stats->number_dispatched_emails_state_ready)->toBe(40)
+            ->and($mailshot->stats->number_delivered_open_success)->toBe(30);
+    });
+
+    test('outbox dispatched emails hydrator adds the archived baseline to the live count', function () {
+        $outbox = createOutboxDirectly($this->shop, OutboxCode::REORDER_REMINDER);
+
+        $emailId = DB::table('dispatched_emails')->insertGetId([
+            'outbox_id'  => $outbox->id,
+            'state'      => 'sent',
+            'data'       => '{}',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        \App\Actions\Comms\Outbox\Hydrators\OutboxHydrateDispatchedEmails::run($outbox->id);
+
+        expect($outbox->stats->refresh()->number_dispatched_emails)->toBe(1);
+
+        $outbox->stats->update([
+            'archived_dispatched_emails' => [
+                'number_dispatched_emails'            => 40,
+                'number_dispatched_emails_state_sent' => 40,
+            ]
+        ]);
+
+        DB::table('dispatched_emails')->where('id', $emailId)->delete();
+
+        \App\Actions\Comms\Outbox\Hydrators\OutboxHydrateDispatchedEmails::run($outbox->id);
+
+        expect($outbox->stats->refresh()->number_dispatched_emails)->toBe(40)
+            ->and($outbox->stats->number_dispatched_emails_state_sent)->toBe(40);
+    });
+
+    test('email bulk run cumulative hydrator adds the archived baseline to the live count', function () {
+        $outbox       = createOutboxDirectly($this->shop, OutboxCode::PRICE_CHANGE_NOTIFICATION);
+        $emailBulkRun = StoreEmailBulkRun::make()->action($outbox->emailOngoingRun, [
+            'subject' => 'Retention baseline',
+            'state'   => \App\Enums\Comms\EmailBulkRun\EmailBulkRunStateEnum::SENDING,
+        ], strict: false);
+
+        $emailBulkRun->stats->update([
+            'archived_dispatched_emails' => [
+                'number_dispatched_emails'  => 40,
+                'number_sent_emails'        => 40,
+                'number_opened_emails'      => 25,
+            ]
+        ]);
+
+        \App\Actions\Comms\EmailBulkRun\Hydrators\EmailBulkRunHydrateCumulativeDispatchedEmails::run(
+            $emailBulkRun,
+            \App\Enums\Comms\DispatchedEmail\DispatchedEmailStateEnum::SENT
+        );
+
+        expect($emailBulkRun->stats->refresh()->number_sent_emails)->toBe(40);
+
+        \App\Actions\Comms\EmailBulkRun\Hydrators\EmailBulkRunHydrateDispatchedEmails::run($emailBulkRun->id);
+
+        expect($emailBulkRun->stats->refresh()->number_dispatched_emails)->toBe(40);
+    });
+
+    test('process outbox time series records does not rebuild periods before the retention cutoff', function () {
+        $outbox    = createOutboxDirectly($this->shop, OutboxCode::REORDER_REMINDER);
+        $archived  = now()->subDays(config('comms.email_retention_days') + 10)->startOfDay();
+        $retained  = now()->subDay()->startOfDay();
+
+        $timeSeries = $outbox->timeSeries()->firstOrCreate(['frequency' => TimeSeriesFrequencyEnum::DAILY], []);
+        $timeSeries->records()->create([
+            'period'            => $archived->format('Y-m-d'),
+            'frequency'         => TimeSeriesFrequencyEnum::DAILY->singleLetter(),
+            'from'              => $archived,
+            'to'                => $archived->copy()->endOfDay(),
+            'dispatched_emails' => 500,
+        ]);
+
+        DB::table('dispatched_emails')->insert([
+            'outbox_id'  => $outbox->id,
+            'state'      => 'sent',
+            'data'       => '{}',
+            'created_at' => $retained->copy()->addHours(9),
+            'updated_at' => now(),
+        ]);
+
+        ProcessOutboxTimeSeriesRecords::run(
+            $outbox->id,
+            TimeSeriesFrequencyEnum::DAILY,
+            $archived->toDateString(),
+            now()->toDateString()
+        );
+
+        $dispatchedOn = fn ($day) => $timeSeries->records()->where('period', $day->format('Y-m-d'))->value('dispatched_emails');
+
+        expect($dispatchedOn($archived))->toBe(500)
+            ->and($dispatchedOn($retained))->toBe(1);
+    });
+
+    test('process outbox time series records returns early when the whole window is before the cutoff', function () {
+        $outbox   = createOutboxDirectly($this->shop, OutboxCode::REORDER_REMINDER);
+        $archived = now()->subDays(config('comms.email_retention_days') + 10)->startOfDay();
+
+        $timeSeries = $outbox->timeSeries()->firstOrCreate(['frequency' => TimeSeriesFrequencyEnum::DAILY], []);
+        $timeSeries->records()->updateOrCreate(
+            ['period' => $archived->format('Y-m-d'), 'frequency' => TimeSeriesFrequencyEnum::DAILY->singleLetter()],
+            ['from' => $archived, 'to' => $archived->copy()->endOfDay(), 'dispatched_emails' => 500]
+        );
+
+        ProcessOutboxTimeSeriesRecords::run(
+            $outbox->id,
+            TimeSeriesFrequencyEnum::DAILY,
+            $archived->toDateString(),
+            $archived->toDateString()
+        );
+
+        expect($timeSeries->records()->where('period', $archived->format('Y-m-d'))->value('dispatched_emails'))->toBe(500);
+    });
+});

--- a/tests/Feature/ProcurementTest.php
+++ b/tests/Feature/ProcurementTest.php
@@ -928,7 +928,7 @@ test('hydrate suppliers', function () {
 
 test('agents record search', function () {
     ReindexAgentSearch::run();
-    $this->artisan('search:agents')->assertExitCode(0);
+    $this->artisan('reindex_search:agents')->assertExitCode(0);
 });
 
 test('suppliers record search', function () {


### PR DESCRIPTION
Step 1 of the boro email log retention work. **Nothing is archived, deleted or pruned here** — this only makes the stats safe to prune against. The archiver will be added to this same PR.

## Why

boro is 489 GB and the email stack is ~217 GB of it (`dispatched_emails` 245M rows / 107 GB, `email_tracking_events` 332M / 61 GB, plus the cascade children). Data goes back to 2018-05-24 and has never been pruned.

The table's real cost is machine aggregation, not human lookups: over 30 days `ProcessOutboxTimeSeriesRecords`' daily rollup is 23,863 calls and 545.8 minutes of DB time (1,372 ms avg), while `GetCustomerTimeline` lookups are 2,145 calls / 3.6 min. Shrinking the table is a performance win as much as a disk win.

Two things would have broken silently once rows start disappearing, and this PR fixes both.

## 1. Counters recount from scratch

Every dispatched email counter is a fresh `count()` over the raw rows, so deleting rows would overwrite historical stats with post deletion numbers — no error, just wrong figures found much later.

The stats rows now carry a nullable `archived_dispatched_emails` jsonb baseline, keyed by the stats column it feeds, and each recount is added on top via a shared trait. One map covers the total, the per state breakdown from `getEnumStats()` **and** the cumulative engagement figures — so per state history does not drift, and a new `DispatchedEmailStateEnum` case needs no schema change.

Applied to all five recounting hydrators: `MailshotHydrateDispatchedEmails`, `OutboxHydrateDispatchedEmails`, `EmailBulkRunHydrateDispatchedEmails`, `MailshotHydrateCumulativeDispatchedEmails` (baselines opened/clicked *before* the derived failure figures, so they stay consistent) and `EmailBulkRunHydrateCumulativeDispatchedEmails`.

Audited for the same pattern: `PostRoomStats`, `OrgPostRoomStats` and `EmailOngoingRunStats` have a `number_dispatched_emails` column but **no hydrator writes it** — display only, currently always 0, left alone. The Shop / Group / Organisation hydrators `SUM(outbox_stats.number_dispatched_emails)`, so they inherit the baseline for free.

## 2. Time series rebuild from source rows

`ProcessOutboxTimeSeriesRecords::fetchDailyResults()` rebuilds the series from raw rows and `syncTimeSeriesRecords()` replaces everything in the window, so re-running it for a pre cutoff period after pruning would zero out history. The window is now clamped to the retention cutoff.

Clamped for `DAILY` only — that is the one frequency built from raw rows. Weekly and up aggregate the daily *records*, which survive archiving, so clamping them would have blocked legitimate historical recomputation.

Cutoff is `config('comms.email_retention_days')`, new `config/comms.php`, `EMAIL_RETENTION_DAYS`, default 90.

## Deploy impact

Effectively none today:

- the baseline column is null everywhere, so the hydrators write byte identical stats
- the migration is `ADD COLUMN … NULL` with no default — metadata only in Postgres, no rewrite, three small tables
- both scheduled rollup paths use short windows well inside 90 days (`Kernel.php:873` is `--from=yesterday --to=today`, `RedoDailyInvoiceTimeSeries` uses `OUTBOX_REPROCESS_DAYS = 3`), so the clamp never fires in scheduled work

**One caveat.** The clamp removes a capability that works today: `outboxes:redo_time_series` with no dates spans 2018→now, and its DAILY pass now stops at 90 days. Since nothing is pruned yet that rebuild is currently valid, so any historical outbox time series backfill should run **before** this deploys, or we add an explicit override flag to the command.

Minor: the two `EmailBulkRun` hydrators now load the stats model (one extra SELECT each) where before they only issued the UPDATE.

## Still to come in this PR

- the archiver itself: neon archive Postgres, chunked copy then delete over `dispatched_emails` + `email_tracking_events` and cascade children
- the archiver must write the per key baselines into `archived_dispatched_emails` in the same transaction as the delete, or the counters go wrong on the first hydration after
- `email_tracking_events` has not been audited for its own recount patterns yet

## Tests

Appended an `email retention` describe block to `tests/Feature/CommsTest.php` (5 tests): each hydrator reports the correct historical total after its source rows are deleted, a pre cutoff daily record survives a run whose window spans the cutoff while an in window day is still rebuilt, and a fully pre cutoff window returns early.

`TEST_TOKEN=… php -d xdebug.mode=off artisan test` — 5 new pass, 11 existing hydrator / time series tests still green. Pint clean.

*Note: this branch also carries a pre-existing unpushed commit of yours, `f70b869 fix(ci): align stale test expectations` (3 files, unrelated). Say the word and I will move it out.*