### PR TITLE
Improve SSR and Iris loading resilience

### DIFF
--- a/app/Services/ReportingSsrGateway.php
+++ b/app/Services/ReportingSsrGateway.php
@@ -9,6 +9,7 @@
 namespace App\Services;
 
 use Exception;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\StrayRequestException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
@@ -31,7 +32,23 @@ class ReportingSsrGateway extends HttpGateway
         }
 
         try {
-            $response = Http::post($this->getUrl('/render'), $page)->throw()->json();
+            $response = Http::connectTimeout(2)
+                ->timeout(10)
+                ->post($this->getUrl('/render'), $page)
+                ->throw()
+                ->json();
+        } catch (RequestException $e) {
+            Log::warning('Inertia SSR request rejected, falling back to CSR', [
+                'url'       => Arr::get($page, 'url'),
+                'component' => Arr::get($page, 'component'),
+                'status'    => $e->response->status(),
+            ]);
+
+            if ($e->response->serverError()) {
+                report($e);
+            }
+
+            return null;
         } catch (Exception $e) {
             if ($e instanceof StrayRequestException) {
                 throw $e;

--- a/resources/js/Iris/Composables/getIrisComponents.ts
+++ b/resources/js/Iris/Composables/getIrisComponents.ts
@@ -7,18 +7,20 @@ import TextContentIris from "@/Iris/Components/IrisBlocks/TextContentIris.vue"
 import WowsbarBannerIris from "@/Iris/Components/IrisBlocks/WowsbarBannerIris.vue" */
 /* import ListProductsEcomIris from "@/Iris/Components/IrisBlocks/Products/Ecom/ListProductsEcomIris.vue" */
 
-// ponytail: a dynamic import that loses its request permanently kills the block, and for header-1 that is
-// the site header. One delayed retry covers the transient case. Deliberately no reload: deploys copy the
-// old chunks forward, so a missing file is not the cause, and a forced reload would throw away whatever
-// the customer had typed.
-const retryOnce = (loader: () => Promise<any>): Promise<any> =>
-	loader().catch(() => new Promise((resolve) => setTimeout(resolve, 250)).then(() => loader()))
-
 const async = (loader: () => Promise<any>): Component =>
 	defineAsyncComponent({
-		loader: () => retryOnce(loader),
+		loader,
 		delay: 200,
-		timeout: 15000,
+		timeout: 30000,
+		onError(_error, retry, fail, attempts) {
+			if (attempts >= 3) {
+				fail()
+
+				return
+			}
+
+			setTimeout(retry, attempts * 1000)
+		},
 	})
 
 //Department


### PR DESCRIPTION
## Why

Sentry showed two recurring production failure patterns:

- `AIKU-18SP`: the SSR renderer rejected some catalogue-family payloads with HTTP 400. The application already falls back to client-side rendering, but these expected client errors were reported as production exceptions and obscured genuine renderer failures.
- `AIKU-IRIS-A` / `AIKU-IRIS-A2`: transient dynamic-import failures and the 15-second async-component timeout left important Iris blocks, including headers and menus, unavailable for users on slow or unstable connections.

## What changed

- Add explicit 2-second connect and 10-second total timeouts to SSR render requests.
- Handle SSR HTTP response failures separately: log the fallback context, report server-side 5xx failures, and avoid reporting deterministic 4xx responses while continuing to return CSR fallback. Connection and unexpected exceptions are still reported.
- Increase the Iris async-component timeout from 15 to 30 seconds.
- Retry failed dynamic imports twice with progressive 1-second and 2-second delays before surfacing the failure.

## Verification

- `php artisan test --compact tests/Unit/ReportingSsrGatewayTest.php` — 2 passed, 5 assertions.
- `vendor/bin/pint --dirty --format agent` — passed.
- `npm run build.iris` — client and SSR production builds passed.
- `git diff --check` — passed.

## Deployment notes

Reload Octane workers after deployment so the updated SSR gateway is loaded. The Iris asset build must be deployed normally.

Sentry: AIKU-18SP, AIKU-IRIS-A, AIKU-IRIS-A2.