### PR TITLE
⬆️ chore(deps): upgrade swiper 11 → 14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
                 "qs": "^6.11.1",
                 "splitpanes": "^3.1.5",
                 "string-to-color": "^2.2.2",
-                "swiper": "^11.2.10",
+                "swiper": "^14.1.0",
                 "tiptap-extension-font-size": "^1.2.0",
                 "ulid": "^2.3.0",
                 "uuid": "^9.0.0",
@@ -7091,17 +7091,17 @@
             }
         },
         "node_modules/swiper": {
-            "version": "11.2.10",
-            "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.10.tgz",
-            "integrity": "sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/swiper/-/swiper-14.1.0.tgz",
+            "integrity": "sha512-ppit/AqmGvThKlXy4I1/9N/gEyb9s/BDHWciWNeIxbfteFKUhPQXrYuOMKszomXKd9WiLd+/0vKdPHW+0N0mhA==",
             "funding": [
                 {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/swiperjs"
+                    "type": "custom",
+                    "url": "https://sponsors.nolimits4web.com"
                 },
                 {
-                    "type": "open_collective",
-                    "url": "http://opencollective.com/swiper"
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nolimits4web"
                 }
             ],
             "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
         "qs": "^6.11.1",
         "splitpanes": "^3.1.5",
         "string-to-color": "^2.2.2",
-        "swiper": "^11.0.5",
+        "swiper": "^14.1.0",
         "tiptap-extension-font-size": "^1.2.0",
         "ulid": "^2.3.0",
         "uuid": "^9.0.0",


### PR DESCRIPTION
> **Frontend review needed.** Stacked on #2564 — base is `deps/npm-security-fixes`, so the diff here is **swiper only** (9 lines). Merge #2564 first and this retargets to `main`.

Fixes critical advisory [GHSA-hmx5-qpq5-p643](https://github.com/advisories/GHSA-hmx5-qpq5-p643) (prototype pollution, affects swiper `6.5.1 - 12.1.1`). The fix requires swiper 14, so this is **three majors**: 11 → 12 → 13 → 14.

Swiper drives the carousels and sliders across the customer-facing storefronts, which is why it is split out rather than riding along with the other security bumps.

## Why the diff is so small
No usage in this repo had to change. Verified directly against the v14 package rather than assumed:

- `swiper/vue` still ships a real implementation exporting `Swiper`, `SwiperSlide`, `useSwiper`, `useSwiperSlide` (it is not a type-only stub).
- Every subpath used here still resolves: `swiper/modules`, `swiper/css{,/navigation,/pagination,/thumbs,/free-mode,/autoplay,/effect-coverflow}`, `swiper/swiper-bundle.css`.
- Every module used here still exports: `Navigation`, `Pagination`, `Autoplay`, `Thumbs`, `FreeMode`, `Mousewheel`, `EffectCoverflow`.
- Grepped all 63 components importing swiper for removed or renamed params — none in use. `autoHeight` still exists in v14.

## Verified running
- All five bundles build (`grp`, `iris`, `retina`, `pupil`, `aiku-public`).
- Storefront hero slider: mounts, 11 pagination bullets, clicking a bullet transitions and the active bullet follows.
- Product carousels: multi-slide layout, spacing and nav arrows correct.
- Product gallery: `Thumbs` stays in sync **both directions** — `slideTo(3)` on the main gallery moves `swiper-slide-thumb-active` to 3, and clicking a thumb drives the main gallery back.
- Every swiper instance on those pages reports `initialized: true`. No console errors.

## ⚠️ What is NOT verified
Local media is largely missing (imgproxy 404s on absent source files), so image-heavy carousels rendered as **empty boxes**. The behaviour is verified; **the pixels are not.**

A build that compiles proves nothing about slide widths, gaps, breakpoint behaviour or arrow positioning — which is exactly where three majors of a CSS-heavy slider library tend to regress. Please do a visual pass on staging where real images exist, particularly:

- homepage hero slider
- TopFamilies / Families2 / Families3
- product gallery with thumbs
- basket recommendations

## Deploy note
The swiper chunk hash changed, which touches the known Iris chunk-load-failure pattern where deploys rsync old assets forward.