### PR TITLE
🕵️ refactor(web): rename david_aw_news blog sub-type to newsletters

### DIFF
--- a/app/Actions/Iris/Blog/IndexIrisBlogs.php
+++ b/app/Actions/Iris/Blog/IndexIrisBlogs.php
@@ -24,7 +24,7 @@ class IndexIrisBlogs extends IrisAction
 
     public const SUB_TYPES = [
         WebpageSubTypeEnum::BLOG,
-        WebpageSubTypeEnum::DAVID_AW_NEWS,
+        WebpageSubTypeEnum::NEWSLETTERS,
         WebpageSubTypeEnum::PRODUCT_GUIDES,
         WebpageSubTypeEnum::BUSINESS_TIPS,
         WebpageSubTypeEnum::INSIGHT,

--- a/app/Actions/Maintenance/Web/RepairWebpageBlogSubType.php
+++ b/app/Actions/Maintenance/Web/RepairWebpageBlogSubType.php
@@ -35,11 +35,11 @@ class RepairWebpageBlogSubType
 
     public function asCommand(Command $command)
     {
-        $travelWebpages = Webpage::where('type', WebpageTypeEnum::BLOG)->where(fn ($q) => $q->where('sub_type', 'davids_travel_blog')->orWhereRaw("code ilike '%david-blog%'"))->get();
+        $travelWebpages = Webpage::where('type', WebpageTypeEnum::BLOG)->whereRaw("code ilike '%david-blog%'")->get();
 
         foreach ($travelWebpages as $webpage) {
             $command->info("Repairing $webpage->slug: Fixing Sub Type & Updating Canonical URL");
-            $this->handle($webpage, WebpageSubTypeEnum::DAVID_AW_NEWS);
+            $this->handle($webpage, WebpageSubTypeEnum::NEWSLETTERS);
         }
 
         $tipsWebpages = Webpage::where('type', WebpageTypeEnum::BLOG)->where('sub_type', 'tips')->get();

--- a/app/Actions/Web/Webpage/Import/BlogHTMLImport.php
+++ b/app/Actions/Web/Webpage/Import/BlogHTMLImport.php
@@ -108,7 +108,7 @@ class BlogHTMLImport implements ToCollection
                 'code'          => $url,
                 'url'           => $url,
                 'type'          => WebpageTypeEnum::BLOG,
-                'sub_type'      => WebpageSubTypeEnum::DAVID_AW_NEWS,
+                'sub_type'      => WebpageSubTypeEnum::NEWSLETTERS,
                 'fieldValue'    => [
                     'title'                         => $row[$titleColumnPos],
                     'published_date'                => $row[$publishedColumnPos],

--- a/app/Actions/Web/Webpage/Iris/ShowIrisBlogDashboard.php
+++ b/app/Actions/Web/Webpage/Iris/ShowIrisBlogDashboard.php
@@ -24,7 +24,7 @@ class ShowIrisBlogDashboard
 
     private const SUB_TYPES = [
         WebpageSubTypeEnum::BLOG,
-        WebpageSubTypeEnum::DAVID_AW_NEWS,
+        WebpageSubTypeEnum::NEWSLETTERS,
         WebpageSubTypeEnum::PRODUCT_GUIDES,
         WebpageSubTypeEnum::BUSINESS_TIPS,
         WebpageSubTypeEnum::INSIGHT,

--- a/app/Actions/Web/Webpage/Iris/ShowIrisNewslettersDashboard.php
+++ b/app/Actions/Web/Webpage/Iris/ShowIrisNewslettersDashboard.php
@@ -12,11 +12,11 @@ use Inertia\Response;
 use Lorisleiva\Actions\ActionRequest;
 use Lorisleiva\Actions\Concerns\AsAction;
 
-class ShowIrisDavidsTravelBlogDashboard
+class ShowIrisNewslettersDashboard
 {
     use AsAction;
 
-    private const SUB_TYPES = [WebpageSubTypeEnum::DAVID_AW_NEWS];
+    private const SUB_TYPES = [WebpageSubTypeEnum::NEWSLETTERS];
 
     public function handle(Website $website): LengthAwarePaginator
     {
@@ -39,7 +39,7 @@ class ShowIrisDavidsTravelBlogDashboard
         return Inertia::render(
             'BlogDashboard',
             [
-                'title' => __("David's Travel Blog"),
+                'title' => __('Newsletters'),
                 'data'  => BlogsIrisResource::collection($blogs),
             ]
         )->table(IndexIrisBlogs::make()->tableStructure($website, IndexIrisBlogs::PREFIX, self::SUB_TYPES));

--- a/app/Enums/Web/Webpage/WebpageBlogTypeEnum.php
+++ b/app/Enums/Web/Webpage/WebpageBlogTypeEnum.php
@@ -16,7 +16,7 @@ enum WebpageBlogTypeEnum: string
     use EnumHelperTrait;
 
     case BLOG           = 'blog';
-    case DAVID_AW_NEWS  = 'david_aw_news';
+    case NEWSLETTERS    = 'newsletters';
     case PRODUCT_GUIDES = 'product_guides';
     case BUSINESS_TIPS  = 'business_tips';
     case INSIGHT        = 'insight';
@@ -24,10 +24,10 @@ enum WebpageBlogTypeEnum: string
     public function label(): string
     {
         return match ($this) {
-            SELF::DAVID_AW_NEWS     => "David's Travel Blog",
-            SELF::PRODUCT_GUIDES    => "Product Guides",
-            SELF::BUSINESS_TIPS     => "Business Tips",
-            SELF::INSIGHT           => "Industry & Retail's Insight",
+            self::NEWSLETTERS       => "Newsletters",
+            self::PRODUCT_GUIDES    => "Product Guides",
+            self::BUSINESS_TIPS     => "Business Tips",
+            self::INSIGHT           => "Industry & Retail's Insight",
             default                 => "Blog",
         };
     }

--- a/app/Enums/Web/Webpage/WebpageSubTypeEnum.php
+++ b/app/Enums/Web/Webpage/WebpageSubTypeEnum.php
@@ -43,7 +43,7 @@ enum WebpageSubTypeEnum: string
     case MAILSHOT = 'mailshot';
 
     case BLOG = 'blog';
-    case DAVID_AW_NEWS  = 'david_aw_news';
+    case NEWSLETTERS    = 'newsletters';
     case PRODUCT_GUIDES = 'product_guides';
     case BUSINESS_TIPS  = 'business_tips';
     case INSIGHT        = 'insight';
@@ -58,10 +58,10 @@ enum WebpageSubTypeEnum: string
             'mailshot'              => __('Mailshot'),
             'article'               => __('Article'),
             'content'               => __('Content'),
-            
+
             'blog'                  => __('Blog'),
             'insight'               => __('Industry & Retail Insights'),
-            'david_aw_news'         => __("David's Travel Blog"),
+            'newsletters'           => __('Newsletters'),
             'product_guides'        => __('Product Guides'),
             'business_tips'         => __('Business Tips'),
         ];
@@ -74,7 +74,7 @@ enum WebpageSubTypeEnum: string
     {
         return [
             self::BLOG,
-            self::DAVID_AW_NEWS,
+            self::NEWSLETTERS,
             self::PRODUCT_GUIDES,
             self::BUSINESS_TIPS,
             self::INSIGHT,
@@ -89,8 +89,8 @@ enum WebpageSubTypeEnum: string
                 'label' => __("Blog"),
             ],
             [
-                'value' => self::DAVID_AW_NEWS->value,
-                'label' => __("David's Travel Blog"),
+                'value' => self::NEWSLETTERS->value,
+                'label' => __('Newsletters'),
             ],
             [
                 'value' => self::PRODUCT_GUIDES->value,

--- a/app/Models/Web/WebpageStats.php
+++ b/app/Models/Web/WebpageStats.php
@@ -81,7 +81,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $number_web_user_requests
  * @property int $number_child_webpages_sub_type_landing_page
  * @property int $number_child_webpages_sub_type_mailshot
- * @property int $number_child_webpages_sub_type_davids_travel_blog
+ * @property int $number_child_webpages_sub_type_newsletters
  * @property int $number_child_webpages_sub_type_tips
  * @property-read \App\Models\Web\Webpage|null $webpage
  * @method static Builder<static>|WebpageStats newModelQuery()

--- a/app/Models/Web/WebsiteStats.php
+++ b/app/Models/Web/WebsiteStats.php
@@ -78,7 +78,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $number_active_announcements
  * @property int $number_inactive_announcements
  * @property int $number_webpages_sub_type_mailshot
- * @property int $number_webpages_sub_type_davids_travel_blog
+ * @property int $number_webpages_sub_type_newsletters
  * @property int $number_webpages_sub_type_tips
  * @property-read \App\Models\Web\Website|null $website
  * @method static Builder<static>|WebsiteStats newModelQuery()

--- a/database/migrations/2026_08_18_120000_rename_webpage_sub_type_david_aw_news_to_newsletters.php
+++ b/database/migrations/2026_08_18_120000_rename_webpage_sub_type_david_aw_news_to_newsletters.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    private array $statsColumns = [
+        'website_stats'          => 'number_webpages_sub_type_',
+        'group_web_stats'        => 'number_webpages_sub_type_',
+        'organisation_web_stats' => 'number_webpages_sub_type_',
+        'webpage_stats'          => 'number_child_webpages_sub_type_',
+    ];
+
+    public function up(): void
+    {
+        DB::table('webpages')->where('sub_type', 'david_aw_news')->update(['sub_type' => 'newsletters']);
+
+        DB::statement("update web_blocks set layout = replace(layout::text, '\"david_aw_news\"', '\"newsletters\"')::jsonb where layout::text like '%\"david_aw_news\"%'");
+        DB::statement("update webpages set published_layout = replace(published_layout::text, '\"david_aw_news\"', '\"newsletters\"')::jsonb where published_layout::text like '%\"david_aw_news\"%'");
+        DB::statement("update snapshots set layout = replace(layout::text, '\"david_aw_news\"', '\"newsletters\"')::jsonb where layout::text like '%\"david_aw_news\"%'");
+        DB::statement("update web_block_types set data = replace(replace(data::text, '\"davids_travel_blog\"', '\"newsletters\"'), 'Read The Blog: David''s AW News', 'Read The Blog: Newsletters')::jsonb where data::text like '%david%'");
+
+        foreach ($this->statsColumns as $table => $prefix) {
+            if (Schema::hasColumn($table, $prefix.'david_aw_news')) {
+                Schema::table($table, function ($blueprint) use ($prefix) {
+                    $blueprint->renameColumn($prefix.'david_aw_news', $prefix.'newsletters');
+                });
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        DB::table('webpages')->where('sub_type', 'newsletters')->update(['sub_type' => 'david_aw_news']);
+
+        DB::statement("update web_blocks set layout = replace(layout::text, '\"newsletters\"', '\"david_aw_news\"')::jsonb where layout::text like '%\"newsletters\"%'");
+        DB::statement("update webpages set published_layout = replace(published_layout::text, '\"newsletters\"', '\"david_aw_news\"')::jsonb where published_layout::text like '%\"newsletters\"%'");
+        DB::statement("update snapshots set layout = replace(layout::text, '\"newsletters\"', '\"david_aw_news\"')::jsonb where layout::text like '%\"newsletters\"%'");
+
+        foreach ($this->statsColumns as $table => $prefix) {
+            if (Schema::hasColumn($table, $prefix.'newsletters')) {
+                Schema::table($table, function ($blueprint) use ($prefix) {
+                    $blueprint->renameColumn($prefix.'newsletters', $prefix.'david_aw_news');
+                });
+            }
+        }
+    }
+};

--- a/database/seeders/datasets/web-block-types/blog-list.json
+++ b/database/seeders/datasets/web-block-types/blog-list.json
@@ -10,9 +10,9 @@
     "is_in_test": false,
 	"data": {
 		"fieldValue": {
-			"title": "Read The Blog: David's AW News",
+			"title": "Read The Blog: Newsletters",
 			"source": "latest",
-			"categories": ["davids_travel_blog"],
+			"categories": ["newsletters"],
 			"picked_posts": [],
 			"number_of_posts": 5,
 			"show_published_date": true,

--- a/resources/js/Components/CMS/Webpage/BlogList/Blueprint.ts
+++ b/resources/js/Components/CMS/Webpage/BlogList/Blueprint.ts
@@ -35,7 +35,7 @@ const categoriesField = {
 		placeholder: "All blog categories",
 		options: [
 			{ label: "Blog", value: "blog" },
-			{ label: "David's Travel Blog", value: "david_aw_news" },
+			{ label: "Newsletters", value: "newsletters" },
 			{ label: "Product Guides", value: "product_guides" },
 			{ label: "Business Tips", value: "business_tips" },
 			{ label: "Industry & Retail's Insight", value: "insight" },

--- a/resources/js/Components/CMS/Webpage/Reviews/ReviewsWorkshop.vue
+++ b/resources/js/Components/CMS/Webpage/Reviews/ReviewsWorkshop.vue
@@ -32,7 +32,7 @@ const reviews = [
   },
   {
     id: 4,
-    name: "David P***",
+    name: "Daniel P***",
     rating: 5,
     message: "Very fast delivery and customer support was fantastic.",
     date: "Posted 2 weeks ago",

--- a/routes/iris/root.php
+++ b/routes/iris/root.php
@@ -20,7 +20,7 @@ use App\Actions\Helpers\Media\UI\DownloadAttachment;
 use App\Actions\Web\Webpage\Iris\ShowIrisSubSitemap;
 use App\Actions\Web\Webpage\Iris\ShowIrisWebpagesList;
 use App\Actions\Web\Webpage\Iris\ShowIrisBlogDashboard;
-use App\Actions\Web\Webpage\Iris\ShowIrisDavidsTravelBlogDashboard;
+use App\Actions\Web\Webpage\Iris\ShowIrisNewslettersDashboard;
 use App\Actions\Web\Webpage\Iris\ShowIrisProductGuidesDashboard;
 use App\Actions\Web\Webpage\Iris\ShowIrisBusinessTipsDashboard;
 use App\Actions\Web\Webpage\Iris\ShowIrisInsightDashboard;
@@ -102,7 +102,7 @@ Route::middleware(["iris-relax-auth:retina"])->group(function () {
         Route::get('/invoice/{invoice:ulid}', IrisPdfInvoice::class)->name('iris_invoice');
         Route::get('/attachment/{media:ulid}', DownloadAttachment::class)->name('iris_attachment');
         Route::get('/blog', ShowIrisBlogDashboard::class)->name('iris_blog');
-        Route::get('/david-aw-news', ShowIrisDavidsTravelBlogDashboard::class)->name('iris_davids_travel_blog');
+        Route::get('/david-aw-news', ShowIrisNewslettersDashboard::class)->name('iris_newsletters');
         Route::get('/product-guides', ShowIrisProductGuidesDashboard::class)->name('iris_product_guides');
         Route::get('/business-tips', ShowIrisBusinessTipsDashboard::class)->name('iris_business_tips');
         Route::get('/insight', ShowIrisInsightDashboard::class)->name('iris_insight');


### PR DESCRIPTION
Removes the personal name from the blog sub-type across code and database, keeping the public iris websites byte-identical.

## Code
- `WebpageSubTypeEnum` / `WebpageBlogTypeEnum`: `DAVID_AW_NEWS = 'david_aw_news'` → `NEWSLETTERS = 'newsletters'`, labels already "Newsletters"
- `ShowIrisDavidsTravelBlogDashboard` → `ShowIrisNewslettersDashboard`; route name `iris_davids_travel_blog` → `iris_newsletters`
- All enum references updated (IndexIrisBlogs, ShowIrisBlogDashboard, BlogHTMLImport, RepairWebpageBlogSubType, Blueprint.ts), stale stats docblocks fixed, blog-list seeder dataset updated

## Database migration
- `webpages.sub_type`: 460 rows `david_aw_news` → `newsletters`
- Replaces the `"david_aw_news"` value inside `web_blocks.layout`, `webpages.published_layout`, `snapshots.layout` and the `web_block_types` seeded data
- Renames `*_sub_type_david_aw_news` counter columns on `website_stats`, `webpage_stats`, `group_web_stats`, `organisation_web_stats`
- Reversible `down()`; local run: 3m24s, all counts verified zero `david_aw_news` remaining

## Unchanged on purpose (public iris URLs must keep working)
- Route path `/david-aw-news` and live webpage URLs/codes (`david-blog-*` on ancientwisdom.biz + awgifts.*) are untouched — only the internal value changed, so rendered pages are identical
- Historic migrations left as-is

Tests: IrisBlogsTest passes against a regenerated test dump.

## How to test with human eyes (iris)

The whole point of this PR is that **iris looks and behaves exactly the same before and after**. Code and data flip together, so any visible difference is a bug. Test on a site that has newsletter pages: ancientwisdom.biz has 407 of them, awgifts.at/cz/eu/fr/hr/hu/it/nl/pl/ro/se/sk have 4–5 each.

Best done as before/after: open each page below **before** deploying, keep the tab, then reload after the migration and compare.

### 1. The newsletters dashboard — the page most likely to break
- Go to `https://ancientwisdom.biz/david-aw-news`
- Expect: the page loads (not a 404), the heading reads **Newsletters**, and the list is populated with blog posts.
- This URL must NOT change. It is public and indexed. If it 404s, the route rename went wrong.

### 2. An individual newsletter post
- From that dashboard, click through to any post, or go straight to `https://ancientwisdom.biz/csv-david-blog-11-27-2023`
- Expect: post opens normally, content and images intact, canonical URL unchanged.

### 3. Blog list blocks on other pages
- Browse the storefront pages that embed a "Blog List" block filtered to this category (the block titled "Read The Blog"). ancientwisdom.biz and awgifts.at/cz/eu/hr/hu/it/pl/se/sk all have one.
- Expect: the block still lists newsletter posts. **An empty or missing block is the main failure mode** — it means a layout JSON somewhere still holds the old `david_aw_news` value while the code now looks for `newsletters`.

### 4. Same check on one non-UK site
- Repeat 1–3 on e.g. `https://awgifts.pl` — confirms the multi-site data got migrated too, not just the main site.

### 5. GRP workshop side (retina)
- Open a webpage workshop containing a Blog List block, then open the block's **categories** dropdown.
- Expect: the option reads **Newsletters**, and if the block already had that category selected it stays selected after save + publish. Publish once and re-check the iris page from step 3 still lists posts.

### 6. Blog index / category navigation
- Open the general blog dashboard and switch between categories.
- Expect: Newsletters appears alongside Product Guides, Business Tips, Industry & Retail's Insight, and selecting it returns posts.

### What "broken" looks like
| Symptom | Likely cause |
|---|---|
| `/david-aw-news` 404s | route rename hit the path instead of just the name |
| Dashboard loads but empty | `webpages.sub_type` rows not migrated |
| Blog List block empty on a page | old value left in `web_blocks.layout` / `published_layout` / `snapshots.layout` |
| Category dropdown shows a raw value instead of "Newsletters" | frontend Blueprint not deployed |

Note the migration takes ~3.5 minutes (the snapshots table is the slow part), so allow for that before judging a page as broken right after deploy.
