### PR TITLE
feat: implement support for multiple product category offers in disco…

### DIFF
--- a/app/Actions/Discounts/Offer/StoreProductCategoryDiscount.php
+++ b/app/Actions/Discounts/Offer/StoreProductCategoryDiscount.php
@@ -26,10 +26,45 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
 use Lorisleiva\Actions\ActionRequest;
 
 class StoreProductCategoryDiscount extends OrgAction
 {
+    /**
+     * @throws \Throwable
+     *
+     * @return array{offers: array<int, Offer>, skipped: array<int, string>}
+     */
+    public function handleMultiple(array $modelData): array
+    {
+        $productCategoryIds = array_unique(
+            Arr::wrap(Arr::pull($modelData, 'product_category_ids') ?? Arr::pull($modelData, 'product_category_id'))
+        );
+
+        $offers  = [];
+        $skipped = [];
+
+        foreach ($productCategoryIds as $productCategoryId) {
+            try {
+                $offer = $this->handle(array_merge($modelData, ['product_category_id' => $productCategoryId]));
+            } catch (ValidationException) {
+                $offer = null;
+            }
+
+            if ($offer) {
+                $offers[] = $offer;
+            } else {
+                $skipped[] = (string)ProductCategory::where('id', $productCategoryId)->value('name');
+            }
+        }
+
+        return [
+            'offers'  => $offers,
+            'skipped' => $skipped,
+        ];
+    }
+
     /**
      * @throws \Throwable
      */
@@ -174,7 +209,9 @@ class StoreProductCategoryDiscount extends OrgAction
             ],
             'end_at'                     => ['nullable', 'required_if:duration,interval', 'date'],
             'percentage_off'             => ['required', 'numeric', 'gt:0', 'lt:100'],
-            'product_category_id'        => ['required', 'integer', 'exists:product_categories,id'],
+            'product_category_id'        => ['required_without:product_category_ids', 'integer', 'exists:product_categories,id'],
+            'product_category_ids'       => ['required_without:product_category_id', 'array', 'min:1'],
+            'product_category_ids.*'     => ['integer', 'exists:product_categories,id'],
             'target_product_category_id' => ['sometimes', 'nullable', 'integer', Rule::exists('product_categories', 'id')->where('shop_id', $this->shop->id)],
         ];
     }
@@ -182,18 +219,33 @@ class StoreProductCategoryDiscount extends OrgAction
 
     /**
      * @throws \Throwable
+     *
+     * @return array{offers: array<int, Offer>, skipped: array<int, string>}
      */
-    public function asController(Shop $shop, ActionRequest $request): Offer
+    public function asController(Shop $shop, ActionRequest $request): array
     {
         $this->initialisationFromShop($shop, $request);
 
-        return $this->handle($this->validatedData);
+        return $this->handleMultiple($this->validatedData);
     }
 
-    public function jsonResponse(Offer $offer): array
+    /**
+     * @param array{offers: array<int, Offer>, skipped: array<int, string>} $result
+     */
+    public function jsonResponse(array $result): array
     {
+        /** @var Offer|null $firstOffer */
+        $firstOffer = Arr::first($result['offers']);
+
         return [
-            'slug' => $offer->slug,
+            'slugs'   => Arr::map($result['offers'], fn (Offer $offer) => $offer->slug),
+            'url'     => $firstOffer ? route('grp.org.shops.show.discounts.campaigns.offer.show', [
+                'organisation'  => $firstOffer->organisation->slug,
+                'shop'          => $firstOffer->shop->slug,
+                'offerCampaign' => $firstOffer->offerCampaign->slug,
+                'offer'         => $firstOffer->slug,
+            ]) : null,
+            'skipped' => $result['skipped'],
         ];
     }
 

--- a/app/Actions/Discounts/Offer/StoreProductCategoryDiscount.php
+++ b/app/Actions/Discounts/Offer/StoreProductCategoryDiscount.php
@@ -34,7 +34,7 @@ class StoreProductCategoryDiscount extends OrgAction
     /**
      * @throws \Throwable
      *
-     * @return array{offers: array<int, Offer>, skipped: array<int, string>}
+     * @return array<int, Offer>
      */
     public function handleMultiple(array $modelData): array
     {
@@ -42,27 +42,29 @@ class StoreProductCategoryDiscount extends OrgAction
             Arr::wrap(Arr::pull($modelData, 'product_category_ids') ?? Arr::pull($modelData, 'product_category_id'))
         );
 
-        $offers  = [];
-        $skipped = [];
+        $offers = [];
 
         foreach ($productCategoryIds as $productCategoryId) {
-            try {
-                $offer = $this->handle(array_merge($modelData, ['product_category_id' => $productCategoryId]));
-            } catch (ValidationException) {
-                $offer = null;
-            }
+            $offer = $this->storeSkippingDuplicate(array_merge($modelData, ['product_category_id' => $productCategoryId]));
 
             if ($offer) {
                 $offers[] = $offer;
-            } else {
-                $skipped[] = (string)ProductCategory::where('id', $productCategoryId)->value('name');
             }
         }
 
-        return [
-            'offers'  => $offers,
-            'skipped' => $skipped,
-        ];
+        return $offers;
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    private function storeSkippingDuplicate(array $modelData): ?Offer
+    {
+        try {
+            return $this->handle($modelData);
+        } catch (ValidationException) {
+            return null;
+        }
     }
 
     /**
@@ -108,13 +110,14 @@ class StoreProductCategoryDiscount extends OrgAction
         $code = Str::lower($offerCampaign->code.'-'.$productCategory->code);
         data_set($modelData, 'code', $code, false);
 
-        $english = Language::where('code', 'en')->first();
-        data_set(
-            $modelData,
-            'name',
-            Translate::run('Category Discount', $english, $productCategory->shop->language, 'gpt-5-nano').' '.$productCategory->code,
-            false
-        );
+        if (!Arr::has($modelData, 'name')) {
+            $english = Language::where('code', 'en')->first();
+            data_set(
+                $modelData,
+                'name',
+                Translate::run('Category Discount', $english, $productCategory->shop->language, 'gpt-5-nano').' '.$productCategory->code
+            );
+        }
 
         data_set($modelData, 'trigger_type', 'ProductCategory');
         data_set($modelData, 'trigger_id', $productCategory->id);
@@ -163,7 +166,7 @@ class StoreProductCategoryDiscount extends OrgAction
 
 
         $offer = StoreOffer::run($offerCampaign, $modelData);
-        ActivateOffer::run($offer, 30);
+        ActivateOffer::dispatch($offer, 30);
 
         return $offer;
     }
@@ -220,7 +223,7 @@ class StoreProductCategoryDiscount extends OrgAction
     /**
      * @throws \Throwable
      *
-     * @return array{offers: array<int, Offer>, skipped: array<int, string>}
+     * @return array<int, Offer>
      */
     public function asController(Shop $shop, ActionRequest $request): array
     {
@@ -230,22 +233,20 @@ class StoreProductCategoryDiscount extends OrgAction
     }
 
     /**
-     * @param array{offers: array<int, Offer>, skipped: array<int, string>} $result
+     * @param array<int, Offer> $offers
      */
-    public function jsonResponse(array $result): array
+    public function jsonResponse(array $offers): array
     {
-        /** @var Offer|null $firstOffer */
-        $firstOffer = Arr::first($result['offers']);
+        /** @var Offer|null $offer */
+        $offer = Arr::first($offers);
 
         return [
-            'slugs'   => Arr::map($result['offers'], fn (Offer $offer) => $offer->slug),
-            'url'     => $firstOffer ? route('grp.org.shops.show.discounts.campaigns.offer.show', [
-                'organisation'  => $firstOffer->organisation->slug,
-                'shop'          => $firstOffer->shop->slug,
-                'offerCampaign' => $firstOffer->offerCampaign->slug,
-                'offer'         => $firstOffer->slug,
+            'url' => $offer ? route('grp.org.shops.show.discounts.campaigns.offer.show', [
+                'organisation'  => $offer->organisation->slug,
+                'shop'          => $offer->shop->slug,
+                'offerCampaign' => $offer->offerCampaign->slug,
+                'offer'         => $offer->slug,
             ]) : null,
-            'skipped' => $result['skipped'],
         ];
     }
 

--- a/app/Actions/Discounts/Offer/StoreProductCategoryDiscount.php
+++ b/app/Actions/Discounts/Offer/StoreProductCategoryDiscount.php
@@ -34,7 +34,7 @@ class StoreProductCategoryDiscount extends OrgAction
     /**
      * @throws \Throwable
      *
-     * @return array<int, Offer>
+     * @return array{offers: array<int, Offer>, skipped: int}
      */
     public function handleMultiple(array $modelData): array
     {
@@ -42,29 +42,28 @@ class StoreProductCategoryDiscount extends OrgAction
             Arr::wrap(Arr::pull($modelData, 'product_category_ids') ?? Arr::pull($modelData, 'product_category_id'))
         );
 
-        $offers = [];
+        $offers  = [];
+        $skipped = 0;
 
         foreach ($productCategoryIds as $productCategoryId) {
-            $offer = $this->storeSkippingDuplicate(array_merge($modelData, ['product_category_id' => $productCategoryId]));
+            try {
+                $offer = $this->handle(array_merge($modelData, ['product_category_id' => $productCategoryId]));
+            } catch (ValidationException $e) {
+                if (Arr::has($e->errors(), 'code')) {
+                    $skipped++;
+                    continue;
+                }
+                throw $e;
+            }
 
             if ($offer) {
                 $offers[] = $offer;
+            } else {
+                $skipped++;
             }
         }
 
-        return $offers;
-    }
-
-    /**
-     * @throws \Throwable
-     */
-    private function storeSkippingDuplicate(array $modelData): ?Offer
-    {
-        try {
-            return $this->handle($modelData);
-        } catch (ValidationException) {
-            return null;
-        }
+        return ['offers' => $offers, 'skipped' => $skipped];
     }
 
     /**
@@ -166,7 +165,7 @@ class StoreProductCategoryDiscount extends OrgAction
 
 
         $offer = StoreOffer::run($offerCampaign, $modelData);
-        ActivateOffer::dispatch($offer, 30);
+        ActivateOffer::run($offer, 30);
 
         return $offer;
     }
@@ -223,7 +222,7 @@ class StoreProductCategoryDiscount extends OrgAction
     /**
      * @throws \Throwable
      *
-     * @return array<int, Offer>
+     * @return array{offers: array<int, Offer>, skipped: int}
      */
     public function asController(Shop $shop, ActionRequest $request): array
     {
@@ -233,20 +232,36 @@ class StoreProductCategoryDiscount extends OrgAction
     }
 
     /**
-     * @param array<int, Offer> $offers
+     * @param array{offers: array<int, Offer>, skipped: int} $result
      */
-    public function jsonResponse(array $offers): array
+    public function jsonResponse(array $result): array
     {
+        $offers = $result['offers'];
+
         /** @var Offer|null $offer */
         $offer = Arr::first($offers);
 
-        return [
-            'url' => $offer ? route('grp.org.shops.show.discounts.campaigns.offer.show', [
+        if (!$offer) {
+            $url = null;
+        } elseif (count($offers) == 1) {
+            $url = route('grp.org.shops.show.discounts.campaigns.offer.show', [
                 'organisation'  => $offer->organisation->slug,
                 'shop'          => $offer->shop->slug,
                 'offerCampaign' => $offer->offerCampaign->slug,
                 'offer'         => $offer->slug,
-            ]) : null,
+            ]);
+        } else {
+            $url = route('grp.org.shops.show.discounts.campaigns.show', [
+                'organisation'  => $offer->organisation->slug,
+                'shop'          => $offer->shop->slug,
+                'offerCampaign' => $offer->offerCampaign->slug,
+            ]);
+        }
+
+        return [
+            'url'     => $url,
+            'created' => count($offers),
+            'skipped' => $result['skipped'],
         ];
     }
 

--- a/resources/js/Components/Offers/ModalCreateCategoryOffers.vue
+++ b/resources/js/Components/Offers/ModalCreateCategoryOffers.vue
@@ -50,7 +50,7 @@ const typeOffer = ref('quantity')
 const offerQtyItems = ref<number | null>(1)
 const offerAmount = ref<number | null>(0)
 const discountPercentage = ref<number | null>(null)
-const offerCategoryId = ref<number | null>(null)
+const offerCategories = ref<{ id: number, name: string }[]>([])
 const categoryType = ref<'department' | 'subdepartment' | 'family'>('department')
 const discountTarget = ref<'same' | 'other'>('same')
 const targetCategoryId = ref<number | null>(null)
@@ -90,7 +90,9 @@ const submitCategoryOffer = () => {
         {
             name: offerLabel.value,
             type: typeOffer.value,
-            product_category_id: offerCategoryId.value || props.product_category_id,
+            product_category_ids: props.product_category_id
+                ? [props.product_category_id]
+                : offerCategories.value.map((category) => category.id),
             trigger_data_item_quantity: offerQtyItems.value != null ? Math.floor(offerQtyItems.value) : null,
             trigger_data_item_amount: offerAmount.value,
             percentage_off: discountPercentage.value != null ? discountPercentage.value / 100 : null,
@@ -101,21 +103,31 @@ const submitCategoryOffer = () => {
         }
     )
     .then((response) => {
+        const createdSlugs: string[] = response.data.slugs ?? []
+        const skippedCategories: string[] = response.data.skipped ?? []
+
+        if (!createdSlugs.length) {
+            notify({
+                title: trans("Something went wrong"),
+                text: trans("No offer was created, the selected categories already have an active offer"),
+                type: "error"
+            })
+            return
+        }
+
         notify({
             title: trans("Success"),
-            text: trans("Successfully submit the data"),
-            type: "success"
+            text: skippedCategories.length
+                ? ctrans("Offers created, skipped (already have an active offer): :categories", { categories: skippedCategories.join(', ') })
+                : trans("Successfully submit the data"),
+            type: skippedCategories.length ? "warn" : "success"
         })
         resetForm();
         isOpenModal.value = false
 
-        if (!props.product_category_id) {
-            router.visit(route('grp.org.shops.show.discounts.campaigns.offer.show', {
-                organisation: props.shop_data.organisation,
-                shop: props.shop_data.slug,
-                offerCampaign: props.shop_data.offercampaign,
-                offer: response.data.slug
-            }))
+        if (createdSlugs.length === 1 && response.data.url) {
+            router.visit(response.data.url)
+            return
         }
         router.reload()
     })
@@ -170,7 +182,7 @@ const resetForm = () => {
     offerQtyItems.value = 1
     offerAmount.value = 0
     categoryType.value = 'department'
-    offerCategoryId.value = props.product_category_id ?? null
+    offerCategories.value = []
     discountTarget.value = 'same'
     targetCategoryId.value = null
     dateType.value = 'permanent'
@@ -180,7 +192,7 @@ const resetForm = () => {
 }
 
 const isFormInvalid = computed(() => {
-    if (!offerCategoryId.value && !props.product_category_id) return true
+    if (!props.product_category_id && !offerCategories.value.length) return true
 
     if (!offerLabel.value) return true
 
@@ -226,7 +238,7 @@ watch([startDate, endDate], () => {
 
 watch(categoryType, () => {
     if (!props.product_category_id) {
-        offerCategoryId.value = null
+        offerCategories.value = []
     }
 })
 
@@ -258,7 +270,8 @@ resetForm();
                     <label for="amount" class="font-medium mb-2 flex items-center gap-x-1">
                         <FontAwesomeIcon icon="fas fa-asterisk" class="font-light text-xs text-red-400 align-middle" />
 
-                        {{ trans('Select category') }}:
+                        {{ trans('Select categories') }}:
+                        <InformationIcon :information="trans('You can select more than one, an offer will be created for each of them')" />
                     </label>
 
                     <div class="flex gap-4">
@@ -286,10 +299,11 @@ resetForm();
 
                     <PureMultiselectInfiniteScroll
                         :key="categoryType"
-                        v-model="offerCategoryId"
+                        v-model="offerCategories"
                         :fetchRoute="activeCategoryRoute"
-                        required
-                        :placeholder="trans('Select category from the list')"
+                        mode="tags"
+                        :object="true"
+                        :placeholder="trans('Select one or more categories from the list')"
                         valueProp="id"
                         labelProp="name" />
 

--- a/resources/js/Components/Offers/ModalCreateCategoryOffers.vue
+++ b/resources/js/Components/Offers/ModalCreateCategoryOffers.vue
@@ -103,13 +103,10 @@ const submitCategoryOffer = () => {
         }
     )
     .then((response) => {
-        const createdSlugs: string[] = response.data.slugs ?? []
-        const skippedCategories: string[] = response.data.skipped ?? []
-
-        if (!createdSlugs.length) {
+        if (!response.data.url) {
             notify({
                 title: trans("Something went wrong"),
-                text: trans("No offer was created, the selected categories already have an active offer"),
+                text: trans("No offer was created, the selected category already has an active offer"),
                 type: "error"
             })
             return
@@ -117,19 +114,13 @@ const submitCategoryOffer = () => {
 
         notify({
             title: trans("Success"),
-            text: skippedCategories.length
-                ? ctrans("Offers created, skipped (already have an active offer): :categories", { categories: skippedCategories.join(', ') })
-                : trans("Successfully submit the data"),
-            type: skippedCategories.length ? "warn" : "success"
+            text: trans("Successfully submit the data"),
+            type: "success"
         })
         resetForm();
         isOpenModal.value = false
 
-        if (response.data.url) {
-            router.visit(response.data.url)
-            return
-        }
-        router.reload()
+        router.visit(response.data.url)
     })
     .catch((error) => {
         const errors = error.response?.data?.errors || {}

--- a/resources/js/Components/Offers/ModalCreateCategoryOffers.vue
+++ b/resources/js/Components/Offers/ModalCreateCategoryOffers.vue
@@ -125,7 +125,7 @@ const submitCategoryOffer = () => {
         resetForm();
         isOpenModal.value = false
 
-        if (createdSlugs.length === 1 && response.data.url) {
+        if (response.data.url) {
             router.visit(response.data.url)
             return
         }

--- a/resources/js/Components/Offers/ModalCreateCategoryOffers.vue
+++ b/resources/js/Components/Offers/ModalCreateCategoryOffers.vue
@@ -103,10 +103,12 @@ const submitCategoryOffer = () => {
         }
     )
     .then((response) => {
-        if (!response.data.url) {
+        const { url, created, skipped } = response.data
+
+        if (!created) {
             notify({
                 title: trans("Something went wrong"),
-                text: trans("No offer was created, the selected category already has an active offer"),
+                text: trans("No offer was created, the selected categories already have an active offer"),
                 type: "error"
             })
             return
@@ -114,13 +116,15 @@ const submitCategoryOffer = () => {
 
         notify({
             title: trans("Success"),
-            text: trans("Successfully submit the data"),
-            type: "success"
+            text: skipped
+                ? trans("Created :created offers, skipped :skipped (already have an active offer)", { created: String(created), skipped: String(skipped) })
+                : trans("Successfully submit the data"),
+            type: skipped ? "warning" : "success"
         })
         resetForm();
         isOpenModal.value = false
 
-        router.visit(response.data.url)
+        router.visit(url)
     })
     .catch((error) => {
         const errors = error.response?.data?.errors || {}

--- a/resources/js/Pages/Grp/Org/Discounts/Offer.vue
+++ b/resources/js/Pages/Grp/Org/Discounts/Offer.vue
@@ -6,7 +6,7 @@
 -->
 
 <script setup lang="ts">
-import { Head, Link } from '@inertiajs/vue3'
+import { Head, Link, usePoll } from '@inertiajs/vue3'
 import PageHeading from '@/Components/Headings/PageHeading.vue'
 import Tabs from '@/Components/Navigation/Tabs.vue'
 import { useTabChange } from '@/Composables/tab-change'
@@ -15,7 +15,7 @@ import { PageHeadingTypes } from '@/types/PageHeading'
 import Coupon from '@/Components/Utils/Coupon.vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { aikuLocaleStructure } from '@/Composables/useLocaleStructure'
-import { inject, computed, ref } from 'vue'
+import { inject, computed, ref, watch } from 'vue'
 import { routeType } from '@/types/route'
 import { trans } from 'laravel-vue-i18n'
 import FamilyOfferLabelDiscount from '@/Components/Utils/Label/DiscountTemplate/CategoryQuantityOrderedOrderInterval/FamilyOfferLabelDiscount.vue'
@@ -120,7 +120,7 @@ const isExpired = computed(() => {
 const stateClass = computed(() => {
     if (isExpired.value) return 'bg-red-200 text-red-800 border'
 
-    switch (state) {
+    switch (state.value) {
         case 'active':
             return 'bg-green-50 text-green-700 border border-green-300'
         case 'in_process':
@@ -157,7 +157,20 @@ const hasTrigger = computed(() => {
     )
 })
 
-const state = props.data.offer_allowances[0]?.state
+const state = computed(() => props.data.offer_allowances[0]?.state)
+
+const { start: startPollingState, stop: stopPollingState } = usePoll(
+    3000,
+    { only: ['data', 'pageHead'] },
+    { autoStart: false }
+)
+
+watch(
+    state,
+    (currentState) => currentState === 'in_process' ? startPollingState() : stopPollingState(),
+    { immediate: true }
+)
+
 const percentage_off = props.data.offer_allowances[0]?.data?.percentage_off
 
 const offerSimulation = ref<OfferSimulation | null>(null)


### PR DESCRIPTION
katarina request = 
if there is a possibility to set up an offer (discounts) on multiple families /department at the same time. Right now we are doing it one by one each time separate, if there could be an option to select multiple families. It's just a suggestion/question.