### PR TITLE
🔊 Sound samples for products (HELP-2975)

### DIFF
--- a/app/Actions/Catalogue/Concerns/CanCloneImages.php
+++ b/app/Actions/Catalogue/Concerns/CanCloneImages.php
@@ -50,7 +50,7 @@ trait CanCloneImages
         foreach ($source->images as $image) {
             $images[$image->id] = [
                 'is_public'       => true,
-                'scope'           => 'photo',
+                'scope'           => $image->pivot->scope === 'audio' ? 'audio' : 'photo',
                 'sub_scope'       => $image->pivot->sub_scope,
                 'caption'         => $image->pivot->caption,
                 'organisation_id' => $target->organisation_id ?? null,
@@ -90,6 +90,7 @@ trait CanCloneImages
             'art4_image_id'            => $source->art4_image_id,
             'art5_image_id'            => $source->art5_image_id,
             'lifestyle_image_id'       => $source->lifestyle_image_id,
+            'audio_id'                 => $source->audio_id,
             'video_url'                => $source->video_url,
         ]);
 

--- a/app/Actions/Catalogue/Product/Json/WithIrisProductsInWebpage.php
+++ b/app/Actions/Catalogue/Product/Json/WithIrisProductsInWebpage.php
@@ -195,6 +195,7 @@ trait WithIrisProductsInWebpage
             'products.web_images',
             'products.is_on_demand',
             'products.is_golden_product',
+            DB::raw("(SELECT media.ulid FROM media WHERE media.id = products.audio_id) as audio_ulid"),
             'webpages.url',
             'webpages.canonical_url',
             'webpages.website_id',

--- a/app/Actions/Catalogue/Product/UI/IndexProductImages.php
+++ b/app/Actions/Catalogue/Product/UI/IndexProductImages.php
@@ -29,6 +29,7 @@ class IndexProductImages extends OrgAction
         $queryBuilder->leftJoin('model_has_media', 'media.id', 'model_has_media.media_id');
         $queryBuilder->where('model_has_media.model_id', $product->id);
         $queryBuilder->where('model_has_media.model_type', 'Product');
+        $queryBuilder->whereRaw("model_has_media.scope IS DISTINCT FROM 'audio'");
 
 
         $queryBuilder

--- a/app/Actions/Goods/TradeUnit/IndexTradeUnitImages.php
+++ b/app/Actions/Goods/TradeUnit/IndexTradeUnitImages.php
@@ -29,6 +29,7 @@ class IndexTradeUnitImages extends OrgAction
         $queryBuilder->leftJoin('model_has_media', 'media.id', 'model_has_media.media_id');
         $queryBuilder->where('model_has_media.model_id', $tradeUnit->id);
         $queryBuilder->where('model_has_media.model_type', 'TradeUnit');
+        $queryBuilder->whereRaw("model_has_media.scope IS DISTINCT FROM 'audio'");
 
 
         $queryBuilder

--- a/app/Actions/Goods/TradeUnit/UI/GetTradeUnitImages.php
+++ b/app/Actions/Goods/TradeUnit/UI/GetTradeUnitImages.php
@@ -41,6 +41,13 @@ class GetTradeUnitImages
                     'tradeUnit' => $tradeUnit->id,
                 ],
             ],
+            'upload_audio_route' => [
+                'method'     => 'post',
+                'name'       => 'grp.models.trade-unit.upload_audio',
+                'parameters' => [
+                    'tradeUnit' => $tradeUnit->id,
+                ],
+            ],
             'delete_images_route' => [
                 'method'     => 'post',
                 'name'       => 'grp.models.trade-unit.detach_image',

--- a/app/Actions/Goods/TradeUnit/UploadAudioToTradeUnit.php
+++ b/app/Actions/Goods/TradeUnit/UploadAudioToTradeUnit.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Wed, 19 Aug 2026 10:05:00 Malaysia Time, Kuala Lumpur, Malaysia
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\Goods\TradeUnit;
+
+use App\Actions\Helpers\Media\StoreMediaFromFile;
+use App\Actions\OrgAction;
+use App\Actions\Traits\WithAttachMediaToModel;
+use App\Models\Goods\TradeUnit;
+use App\Models\Helpers\Media;
+use Lorisleiva\Actions\ActionRequest;
+
+class UploadAudioToTradeUnit extends OrgAction
+{
+    use WithAttachMediaToModel;
+
+    public function handle(TradeUnit $tradeUnit, array $modelData): Media
+    {
+        $audioFile = $modelData['audio'];
+
+        $media = StoreMediaFromFile::run(
+            $tradeUnit,
+            [
+                'path'         => $audioFile->getPathName(),
+                'originalName' => $audioFile->getClientOriginalName(),
+                'extension'    => $audioFile->guessClientExtension(),
+                'checksum'     => md5_file($audioFile->getPathName()),
+            ],
+            'audio',
+            'audio'
+        );
+
+        $this->attachMediaToModel($tradeUnit, $media, 'audio');
+
+        UpdateTradeUnitImages::make()->handle($tradeUnit, ['audio_id' => $media->id], true);
+
+        return $media;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'audio' => ['required', 'file', 'mimes:mp3,wav,ogg,oga,m4a,aac,flac', 'max:50000'],
+        ];
+    }
+
+    public function asController(TradeUnit $tradeUnit, ActionRequest $request): void
+    {
+        $this->initialisationFromGroup($tradeUnit->group, $request);
+
+        $this->handle($tradeUnit, $this->validatedData);
+    }
+}

--- a/app/Actions/Helpers/Media/StoreMediaFromFile.php
+++ b/app/Actions/Helpers/Media/StoreMediaFromFile.php
@@ -40,8 +40,10 @@ class StoreMediaFromFile
             ->usingFileName(hash('crc32b', $imageData['checksum']).'.'.$extension)
             ->toMediaCollection($collection);
 
-        UpdateIsAnimatedMedia::run($media, $imageData['path']);
-        MediaHydrateDimensions::run($media);
+        if ($type === 'image') {
+            UpdateIsAnimatedMedia::run($media, $imageData['path']);
+            MediaHydrateDimensions::run($media);
+        }
         return $media;
     }
 }

--- a/app/Actions/Helpers/Media/UI/ShowIrisAudio.php
+++ b/app/Actions/Helpers/Media/UI/ShowIrisAudio.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Wed, 19 Aug 2026 12:00:00 Malaysia Time, Kuala Lumpur, Malaysia
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\Helpers\Media\UI;
+
+use App\Models\Helpers\Media;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+class ShowIrisAudio
+{
+    use AsAction;
+
+    public function asController(Media $media): BinaryFileResponse
+    {
+        $isAudio = str_starts_with((string) $media->mime_type, 'audio/')
+            || in_array(strtolower(pathinfo($media->file_name, PATHINFO_EXTENSION)), ['mp3', 'wav', 'ogg', 'oga', 'm4a', 'aac', 'flac'], true);
+        abort_unless($isAudio, 404);
+
+        return response()->file($media->getPath(), [
+            'Content-Type'   => $media->mime_type,
+            'Content-Length' => $media->size,
+            'Cache-Control'  => 'public, max-age=31536000, immutable',
+        ]);
+    }
+}

--- a/app/Actions/Masters/MasterAsset/CloneMasterAssetImagesFromTradeUnits.php
+++ b/app/Actions/Masters/MasterAsset/CloneMasterAssetImagesFromTradeUnits.php
@@ -39,7 +39,7 @@ class CloneMasterAssetImagesFromTradeUnits implements ShouldBeUnique
         foreach ($tradeUnit->images as $image) {
             $images[$image->id] = [
                 'is_public'  => true,
-                'scope'      => 'photo',
+                'scope'      => $image->pivot->scope === 'audio' ? 'audio' : 'photo',
                 'sub_scope'  => $image->pivot->sub_scope,
                 'caption'    => $image->pivot->caption,
                 'group_id'   => $masterAsset->group_id,
@@ -71,6 +71,7 @@ class CloneMasterAssetImagesFromTradeUnits implements ShouldBeUnique
             'art3_image_id'            => $tradeUnit->art3_image_id,
             'art4_image_id'            => $tradeUnit->art4_image_id,
             'art5_image_id'            => $tradeUnit->art5_image_id,
+            'audio_id'                 => $tradeUnit->audio_id,
             'video_url'                => $tradeUnit->video_url,
         ]);
     }

--- a/app/Actions/Masters/MasterAsset/GetMasterProductImages.php
+++ b/app/Actions/Masters/MasterAsset/GetMasterProductImages.php
@@ -44,6 +44,13 @@ class GetMasterProductImages
                     'masterAsset' => $masterAsset->id,
                 ],
             ],
+            'upload_audio_route' => [
+                'method'     => 'post',
+                'name'       => 'grp.models.master_asset.upload_audio',
+                'parameters' => [
+                    'masterAsset' => $masterAsset->id,
+                ],
+            ],
             'delete_images_route' => [
                 'method'     => 'post',
                 'name'       => 'grp.models.master_asset.delete_images',

--- a/app/Actions/Masters/MasterAsset/UI/IndexMasterProductImages.php
+++ b/app/Actions/Masters/MasterAsset/UI/IndexMasterProductImages.php
@@ -29,6 +29,7 @@ class IndexMasterProductImages extends OrgAction
         $queryBuilder->leftJoin('model_has_media', 'media.id', 'model_has_media.media_id');
         $queryBuilder->where('model_has_media.model_id', $masterAsset->id);
         $queryBuilder->where('model_has_media.model_type', 'MasterAsset');
+        $queryBuilder->whereRaw("model_has_media.scope IS DISTINCT FROM 'audio'");
 
 
         $queryBuilder

--- a/app/Actions/Masters/MasterAsset/UploadAudioToMasterProduct.php
+++ b/app/Actions/Masters/MasterAsset/UploadAudioToMasterProduct.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Wed, 19 Aug 2026 10:05:00 Malaysia Time, Kuala Lumpur, Malaysia
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\Masters\MasterAsset;
+
+use App\Actions\Helpers\Media\StoreMediaFromFile;
+use App\Actions\OrgAction;
+use App\Actions\Traits\WithAttachMediaToModel;
+use App\Models\Helpers\Media;
+use App\Models\Masters\MasterAsset;
+use Lorisleiva\Actions\ActionRequest;
+
+class UploadAudioToMasterProduct extends OrgAction
+{
+    use WithAttachMediaToModel;
+
+    public function handle(MasterAsset $masterAsset, array $modelData): Media
+    {
+        $audioFile = $modelData['audio'];
+
+        $media = StoreMediaFromFile::run(
+            $masterAsset,
+            [
+                'path'         => $audioFile->getPathName(),
+                'originalName' => $audioFile->getClientOriginalName(),
+                'extension'    => $audioFile->guessClientExtension(),
+                'checksum'     => md5_file($audioFile->getPathName()),
+            ],
+            'audio',
+            'audio'
+        );
+
+        $this->attachMediaToModel($masterAsset, $media, 'audio');
+
+        UpdateMasterProductImages::make()->handle($masterAsset, ['audio_id' => $media->id], true);
+
+        return $media;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'audio' => ['required', 'file', 'mimes:mp3,wav,ogg,oga,m4a,aac,flac', 'max:50000'],
+        ];
+    }
+
+    public function asController(MasterAsset $masterAsset, ActionRequest $request): void
+    {
+        $this->initialisationFromGroup($masterAsset->group, $request);
+
+        $this->handle($masterAsset, $this->validatedData);
+    }
+}

--- a/app/Actions/Traits/HasBucketImages.php
+++ b/app/Actions/Traits/HasBucketImages.php
@@ -195,6 +195,17 @@ trait HasBucketImages
                     'height' => $model->art5Image->height ?? 0
                 ]
             ],
+            [
+                'label'        => __('Sound sample'),
+                'type'         => 'audio',
+                'information'  => __('Audio sample, e.g. for musical instruments or singing bowls'),
+                'column_in_db' => 'audio_id',
+                'id'           => $model->audio_id,
+                'audio'        => $model->audio ? [
+                    'url'  => route('grp.media.show', $model->audio->ulid),
+                    'name' => $model->audio->name,
+                ] : null,
+            ],
         ];
 
         if (!$withCaptions) {

--- a/app/Actions/Traits/WithImageColumns.php
+++ b/app/Actions/Traits/WithImageColumns.php
@@ -27,6 +27,7 @@ trait WithImageColumns
             'size_comparison_image_id',
             'lifestyle_image_id',
             'top_image_id',
+            'audio_id',
         ];
     }
 }

--- a/app/Actions/Traits/WithImageUpdate.php
+++ b/app/Actions/Traits/WithImageUpdate.php
@@ -32,6 +32,7 @@ trait WithImageUpdate
             'art3_image_id' => 'art3',
             'art4_image_id' => 'art4',
             'art5_image_id' => 'art5',
+            'audio_id' => 'audio',
         ];
     }
 
@@ -86,6 +87,7 @@ trait WithImageUpdate
             'art3_image_id' => ['sometimes', 'nullable', 'exists:media,id'],
             'art4_image_id' => ['sometimes', 'nullable', 'exists:media,id'],
             'art5_image_id' => ['sometimes', 'nullable', 'exists:media,id'],
+            'audio_id' => ['sometimes', 'nullable', 'exists:media,id'],
             'video_url' => ['sometimes', 'nullable'],
         ];
     }

--- a/app/Http/Resources/Catalogue/IrisAuthenticatedProductsInWebpageResource.php
+++ b/app/Http/Resources/Catalogue/IrisAuthenticatedProductsInWebpageResource.php
@@ -158,6 +158,7 @@ class IrisAuthenticatedProductsInWebpageResource extends JsonResource
             'url'                        => $this->canonical_url,
             'top_seller'                 => $this->top_seller,
             'web_images'                 => $this->getCardWebImages($this->web_images),
+            'audio'                      => $this->audio_ulid ? '/audio/'.$this->audio_ulid : null,
             'transaction_id'             => $this->transaction_id ?? null,
             'quantity_ordered'           => (int)$this->quantity_ordered ?? 0,
             'quantity_ordered_new'       => (int)$this->quantity_ordered ?? 0,  // To editable in Frontend

--- a/app/Http/Resources/Catalogue/IrisProductsInWebpageResource.php
+++ b/app/Http/Resources/Catalogue/IrisProductsInWebpageResource.php
@@ -85,6 +85,7 @@ class IrisProductsInWebpageResource extends JsonResource
             'url'             => $url,
             'top_seller'      => $this->top_seller,
             'web_images'      => $this->getCardWebImages($this->web_images),
+            'audio'           => $this->audio_ulid ? '/audio/'.$this->audio_ulid : null,
             'transaction_id'  => $this->transaction_id,
             'is_on_demand'    => $this->is_on_demand,
             'is_variant'      => $this->is_variant,

--- a/app/Http/Resources/Web/WebBlockProductResource.php
+++ b/app/Http/Resources/Web/WebBlockProductResource.php
@@ -114,6 +114,7 @@ class WebBlockProductResource extends JsonResource
             'units'             => $units,
             'unit'              => $product->unit,
             'web_images'        => $product->web_images,
+            'audio'             => $product->audio ? '/audio/'.$product->audio->ulid : null,
             'created_at'        => $product->created_at,
             'updated_at'        => $product->updated_at,
             'images'            => $product->bucket_images ? $this->getImagesData($product, true, 800) : $this->getResizedMediaImages($product, 800),

--- a/app/Models/Traits/HasImage.php
+++ b/app/Models/Traits/HasImage.php
@@ -37,6 +37,11 @@ trait HasImage
         return null;
     }
 
+    public function audio(): HasOne
+    {
+        return $this->hasOne(Media::class, 'id', 'audio_id');
+    }
+
     public function seoImage(): HasOne
     {
         return $this->hasOne(Media::class, 'id', 'seo_image_id');

--- a/database/migrations/2026_08_19_100000_add_audio_id_to_assets_tables.php
+++ b/database/migrations/2026_08_19_100000_add_audio_id_to_assets_tables.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Wed, 19 Aug 2026 10:00:00 Malaysia Time, Kuala Lumpur, Malaysia
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    private array $tables = ['master_assets', 'products', 'trade_units'];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $tableName) {
+            Schema::table($tableName, function (Blueprint $table) {
+                $table->integer('audio_id')->nullable()->index();
+                $table->foreign('audio_id')->references('id')->on('media')->nullOnDelete();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $tableName) {
+            Schema::table($tableName, function (Blueprint $table) {
+                $table->dropForeign(['audio_id']);
+                $table->dropColumn('audio_id');
+            });
+        }
+    }
+};

--- a/resources/js/Components/Goods/ImagesManagement.vue
+++ b/resources/js/Components/Goods/ImagesManagement.vue
@@ -4,7 +4,8 @@ import { router } from "@inertiajs/vue3"
 import { trans } from "laravel-vue-i18n"
 import { notify } from "@kyvg/vue3-notification"
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome"
-import { faImage, faPencil, faUnlink, faUpload, faVideo, faInfoCircle } from "@fal"
+import { faImage, faMusic, faPencil, faUnlink, faUpload, faVideo, faInfoCircle } from "@fal"
+import AudioWaveform from "@/Components/Pure/AudioWaveform.vue"
 import Button from "@/Components/Elements/Buttons/Button.vue"
 import Image from "@common/Components/Image.vue"
 import axios from "axios"
@@ -26,6 +27,7 @@ const props = defineProps<{
         bucket_images?: boolean
         images_update_route: routeType
         upload_images_route: routeType
+        upload_audio_route?: routeType
         delete_images_route: routeType
         update_image_alt_route?: routeType
         images_category_box: {
@@ -34,6 +36,7 @@ const props = defineProps<{
             column_in_db: string
             url?: string
             images?: ImageTS
+            audio?: { url: string, name: string } | null
             information?: string
             id?: number
         }[]
@@ -238,6 +241,32 @@ function onDropFile(event: DragEvent) {
     if (event.dataTransfer?.files?.length) uploadFiles(event.dataTransfer.files)
 }
 
+async function uploadAudioFile(event: Event) {
+    const input = event.target as HTMLInputElement
+    const file = input.files?.[0]
+    if (!file || !props.data.upload_audio_route) return
+
+    const formData = new FormData()
+    formData.append("audio", file)
+
+    try {
+        loadingSubmit.value = "audio_id"
+        await axios.post(
+            route(props.data.upload_audio_route.name, props.data.upload_audio_route.parameters),
+            formData,
+            { headers: { "Content-Type": "multipart/form-data" } }
+        )
+        notifySuccess(trans("Sound sample uploaded successfully"))
+        router.reload({ only: ["images"] })
+    } catch (e) {
+        console.error(e)
+        notifyError(trans("Failed to upload sound sample"))
+    } finally {
+        loadingSubmit.value = null
+        input.value = ""
+    }
+}
+
 function onDeletefilesInBox(categoryBox: any) {
     let payload = { [categoryBox.column_in_db]: null }
     onSubmitImage(payload, categoryBox)
@@ -335,6 +364,15 @@ function onDeleteFilesInList(categoryBox: any) {
                                 selectedVideoToUpdate = { ...categoryBox }
                                 isModalEditVideo = true
                             }" :icon="faPencil" class="text-gray-400 hover:text-gray-600 cursor-pointer" fixed-width />
+                            <label v-if="categoryBox.type == 'audio' && editable && data.upload_audio_route"
+                                class="cursor-pointer" v-tooltip="trans('Upload sound sample')">
+                                <FontAwesomeIcon :icon="faUpload" class="text-gray-400 hover:text-gray-600" fixed-width />
+                                <input type="file" accept="audio/*,.mp3,.wav,.ogg,.m4a,.aac,.flac" class="hidden"
+                                    @change="uploadAudioFile($event)" />
+                            </label>
+                            <FontAwesomeIcon v-if="categoryBox.type == 'audio' && categoryBox.audio && editable"
+                                :icon="faUnlink" @click="() => onDeleteFilesInList(categoryBox)"
+                                class="text-gray-400 text-red-600 cursor-pointer text-xs" />
                             <FontAwesomeIcon v-if="(categoryBox.images || categoryBox.url) && editable" :icon="faUnlink"
                                 @click="() => onDeletefilesInBox(categoryBox)"
                                 class="text-gray-400 text-red-600 cursor-pointer text-xs" />
@@ -352,6 +390,19 @@ function onDeleteFilesInList(categoryBox: any) {
                             <FontAwesomeIcon :icon="faImage" class="mb-1 text-2xl" />
                             <span class="text-[12px] font-medium">{{ trans('Drop image here') }}</span>
                         </div>
+                    </div>
+
+                    <div v-if="categoryBox.type == 'audio'"
+                        class="relative flex h-36 w-full items-center justify-center bg-gray-50 px-2">
+                        <AudioWaveform v-if="categoryBox.audio" :src="categoryBox.audio.url" />
+                        <label v-else class="flex flex-col items-center justify-center text-gray-400"
+                            :class="editable && data.upload_audio_route ? 'cursor-pointer' : ''">
+                            <FontAwesomeIcon :icon="faMusic" class="mb-1 text-2xl" />
+                            <span class="text-[12px] font-medium">{{ trans('Upload sound sample') }}</span>
+                            <input v-if="editable && data.upload_audio_route" type="file"
+                                accept="audio/*,.mp3,.wav,.ogg,.m4a,.aac,.flac" class="hidden"
+                                @change="uploadAudioFile($event)" />
+                        </label>
                     </div>
 
                     <div v-if="categoryBox.type == 'video'"

--- a/resources/js/Components/Pure/AudioWaveform.vue
+++ b/resources/js/Components/Pure/AudioWaveform.vue
@@ -1,0 +1,186 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount, watch } from "vue"
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome"
+import { faPlay, faPause } from "@fas"
+
+const props = defineProps<{ src: string }>()
+
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+const isPlaying = ref(false)
+const bars = ref<number[]>([])
+let audio: HTMLAudioElement | null = null
+let analyser: AnalyserNode | null = null
+let playbackContext: AudioContext | null = null
+let frequencyData: Uint8Array | null = null
+let rafId = 0
+
+const BAR_COUNT = 48
+
+async function loadWaveform() {
+    const audioContext = new AudioContext()
+    try {
+        const arrayBuffer = await (await fetch(props.src)).arrayBuffer()
+        const decoded = await audioContext.decodeAudioData(arrayBuffer)
+        const channel = decoded.getChannelData(0)
+        const blockSize = Math.floor(channel.length / BAR_COUNT)
+        const peaks: number[] = []
+        for (let i = 0; i < BAR_COUNT; i++) {
+            let peak = 0
+            // ponytail: sample every 32nd frame, plenty of resolution for a thumbnail waveform
+            for (let j = i * blockSize; j < (i + 1) * blockSize; j += 32) {
+                const value = Math.abs(channel[j])
+                if (value > peak) peak = value
+            }
+            peaks.push(peak)
+        }
+        const maxPeak = Math.max(...peaks, 0.01)
+        bars.value = peaks.map((peak) => Math.max(peak / maxPeak, 0.08))
+    } catch {
+        bars.value = Array.from({ length: BAR_COUNT }, (_, i) => 0.3 + 0.5 * Math.abs(Math.sin(i * 0.7)))
+    } finally {
+        audioContext.close()
+    }
+    draw(0)
+}
+
+function draw(progress: number) {
+    const canvas = canvasRef.value
+    if (!canvas || !bars.value.length) return
+
+    const dpr = window.devicePixelRatio || 1
+    const width = canvas.clientWidth
+    const height = canvas.clientHeight
+    canvas.width = width * dpr
+    canvas.height = height * dpr
+
+    const context = canvas.getContext("2d")
+    if (!context) return
+    context.scale(dpr, dpr)
+    context.clearRect(0, 0, width, height)
+
+    const gap = 2
+    const barWidth = (width - gap * (BAR_COUNT - 1)) / BAR_COUNT
+
+    bars.value.forEach((value, i) => {
+        const barHeight = Math.max(value * height * 0.9, 3)
+        const x = i * (barWidth + gap)
+        const y = (height - barHeight) / 2
+        const isPlayed = (i + 0.5) / BAR_COUNT <= progress
+        const opacity = progress === 0 || isPlayed ? 1 : 0.25
+        context.fillStyle = `hsla(${(i / BAR_COUNT) * 300}, 85%, 48%, ${opacity})`
+        context.beginPath()
+        context.roundRect(x, y, barWidth, barHeight, barWidth / 2)
+        context.fill()
+    })
+}
+
+function drawSpectrum() {
+    const canvas = canvasRef.value
+    if (!canvas || !analyser || !frequencyData) return
+
+    analyser.getByteFrequencyData(frequencyData)
+
+    const dpr = window.devicePixelRatio || 1
+    const width = canvas.clientWidth
+    const height = canvas.clientHeight
+    canvas.width = width * dpr
+    canvas.height = height * dpr
+
+    const context = canvas.getContext("2d")
+    if (!context) return
+    context.scale(dpr, dpr)
+    context.clearRect(0, 0, width, height)
+
+    const gap = 2
+    const barWidth = (width - gap * (BAR_COUNT - 1)) / BAR_COUNT
+    // ponytail: log-ish bucketing by skipping the top third of FFT bins, where music has little energy
+    const usableBins = Math.floor(frequencyData.length * 0.66)
+    const binsPerBar = Math.max(1, Math.floor(usableBins / BAR_COUNT))
+
+    for (let i = 0; i < BAR_COUNT; i++) {
+        let sum = 0
+        for (let j = i * binsPerBar; j < (i + 1) * binsPerBar; j++) {
+            sum += frequencyData[j]
+        }
+        const value = sum / binsPerBar / 255
+        const barHeight = Math.max(value * height * 0.95, 3)
+        const x = i * (barWidth + gap)
+        const y = (height - barHeight) / 2
+        context.fillStyle = `hsl(${(i / BAR_COUNT) * 300}, 85%, 48%)`
+        context.beginPath()
+        context.roundRect(x, y, barWidth, barHeight, barWidth / 2)
+        context.fill()
+    }
+}
+
+function tick() {
+    if (audio && isPlaying.value) {
+        drawSpectrum()
+        rafId = requestAnimationFrame(tick)
+    }
+}
+
+function togglePlay() {
+    if (!audio) {
+        audio = new Audio(props.src)
+        audio.crossOrigin = "anonymous"
+        audio.onended = () => {
+            isPlaying.value = false
+            cancelAnimationFrame(rafId)
+            draw(0)
+        }
+        playbackContext = new AudioContext()
+        const source = playbackContext.createMediaElementSource(audio)
+        analyser = playbackContext.createAnalyser()
+        analyser.fftSize = 256
+        analyser.smoothingTimeConstant = 0.75
+        source.connect(analyser)
+        analyser.connect(playbackContext.destination)
+        frequencyData = new Uint8Array(analyser.frequencyBinCount)
+    }
+    playbackContext?.resume()
+
+    if (isPlaying.value) {
+        audio.pause()
+        isPlaying.value = false
+        cancelAnimationFrame(rafId)
+        draw(audio.duration ? audio.currentTime / audio.duration : 0)
+    } else {
+        audio.play()
+        isPlaying.value = true
+        tick()
+    }
+}
+
+function stopAndReset() {
+    if (audio) {
+        audio.pause()
+        audio = null
+    }
+    playbackContext?.close()
+    playbackContext = null
+    analyser = null
+    frequencyData = null
+    isPlaying.value = false
+    cancelAnimationFrame(rafId)
+}
+
+watch(() => props.src, () => {
+    stopAndReset()
+    loadWaveform()
+})
+
+onMounted(loadWaveform)
+onBeforeUnmount(stopAndReset)
+</script>
+
+<template>
+    <div class="relative h-full w-full group/audio" @click.stop="togglePlay()">
+        <canvas ref="canvasRef" class="h-full w-full" />
+        <div class="absolute inset-0 flex items-center justify-center opacity-0 group-hover/audio:opacity-100 transition cursor-pointer">
+            <div class="flex h-9 w-9 items-center justify-center rounded-full bg-gray-800/70 text-white">
+                <FontAwesomeIcon :icon="isPlaying ? faPause : faPlay" class="text-sm" :class="{ 'pl-0.5': !isPlaying }" />
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/Iris/Components/IrisBlocks/Product/Ecom/ProductIris1Ecom.vue
+++ b/resources/js/Iris/Components/IrisBlocks/Product/Ecom/ProductIris1Ecom.vue
@@ -11,6 +11,7 @@ import ProductContentsIris from "@/Components/CMS/Webpage/Product1/ProductConten
 import InformationSideProduct from "@/Components/CMS/Webpage/Product1/InformationSideProduct.vue"
 
 import Image from "@common/Components/Image.vue"
+import ProductSoundButton from "@/Iris/Components/ProductSoundButton.vue"
 import LoadingIcon from "@/Components/Utils/LoadingIcon.vue"
 import Button from "@/Components/Elements/Buttons/Button.vue"
 import LinkIris from "@/Iris/Components/LinkIris.vue"
@@ -255,8 +256,9 @@ onMounted(async () => {
         <div class="grid grid-cols-12 gap-x-10 mb-2">
             <!-- LEFT: Images -->
             <div class="col-span-7 bg-white" >
-                <div class="py-1 w-full">
+                <div class="py-1 w-full relative">
                     <ImageProducts :key="product.code" :images="validImages" :video="videoSetup?.url" />
+                    <ProductSoundButton v-if="product.audio" :src="product.audio" />
                 </div>
 
                 <!-- TAGS -->
@@ -548,7 +550,10 @@ onMounted(async () => {
         </div>
 
         <!-- MEDIA -->
-        <ImageProducts :images="validImages" :video="videoSetup?.url" />
+        <div class="relative">
+            <ImageProducts :images="validImages" :video="videoSetup?.url" />
+            <ProductSoundButton v-if="product.audio" :src="product.audio" />
+        </div>
         
 
         <!-- STOCK + FAVOURITE -->

--- a/resources/js/Iris/Components/IrisBlocks/Products/Ecom/ProductCard/ProductCardEcom1.vue
+++ b/resources/js/Iris/Components/IrisBlocks/Products/Ecom/ProductCard/ProductCardEcom1.vue
@@ -21,6 +21,7 @@ import BestsellerBadge from '@/Components/CMS/Webpage/Products/BestsellerBadge.v
 import GoldenProductBadge from '@/Components/CMS/Webpage/Products/GoldenProductBadge.vue'
 import LabelComingSoon from '@/Components/Iris/Products/LabelComingSoon.vue'
 import Prices4 from '@/Iris/Components/BlocksUtils/Prices4.vue'
+import ProductSoundButton from '@/Iris/Components/ProductSoundButton.vue'
 import { routeType } from '@/types/route'
 
 library.add(faStarHalfAlt, faQuestionCircle)
@@ -223,6 +224,8 @@ defineExpose({
 
                     </slot>
                 </div>
+
+                <ProductSoundButton v-if="product.audio" :src="product.audio" />
 
                 <!-- Section: Golden product, Favourite -->
                 <div v-if="product.is_golden_product || (layout?.iris?.is_logged_in && basketButton && !product.is_variant)"

--- a/resources/js/Iris/Components/IrisBlocks/Products/Ecom/ProductCard/ProductCardEcom2.vue
+++ b/resources/js/Iris/Components/IrisBlocks/Products/Ecom/ProductCard/ProductCardEcom2.vue
@@ -12,6 +12,7 @@ import NewAddToCartButton from '@/Components/CMS/Webpage/Products/NewAddToCartBu
 import BestsellerBadge from '@/Components/CMS/Webpage/Products/BestsellerBadge.vue'
 import GoldenProductBadge from '@/Components/CMS/Webpage/Products/GoldenProductBadge.vue'
 import LinkIris from '@/Iris/Components/LinkIris.vue'
+import ProductSoundButton from '@/Iris/Components/ProductSoundButton.vue'
 import Button from '@/Components/Elements/Buttons/Button.vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
@@ -152,6 +153,8 @@ defineExpose({
                     <div class="absolute md:bottom-4 lg:bottom-0 xl:bottom-0 bottom-0 left-0 text-gray-500 text-xl z-10 offer ">
                          <DiscountByType :offers_data="product?.product_offers_data" template="max_discount" />
                     </div>
+
+                    <ProductSoundButton v-if="product.audio" :src="product.audio" />
 
                     <!-- GOLDEN PRODUCT + FAVOURITE -->
                     <div v-if="product.is_golden_product || (layout?.iris?.is_logged_in && !product.variant)"

--- a/resources/js/Iris/Components/IrisBlocks/Products/Ecom/ProductCard/ProductCardEcom3.vue
+++ b/resources/js/Iris/Components/IrisBlocks/Products/Ecom/ProductCard/ProductCardEcom3.vue
@@ -23,6 +23,7 @@ import GoldenProductBadge from '@/Components/CMS/Webpage/Products/GoldenProductB
 import { routeType } from '@/types/route'
 /* import LabelComingSoon from '@/Components/Iris/Products/LabelComingSoon.vue' */
 import Prices4 from '@/Iris/Components/BlocksUtils/Prices4.vue'
+import ProductSoundButton from '@/Iris/Components/ProductSoundButton.vue'
 
 library.add(faStarHalfAlt, faQuestionCircle)
 const locale = useLocaleStore()
@@ -270,6 +271,8 @@ defineExpose({
 
                     </slot>
                 </div>
+
+                <ProductSoundButton v-if="product.audio" :src="product.audio" />
 
                 <!-- Section: Golden product, Favourite -->
                 <div v-if="product.is_golden_product || (layout?.iris?.is_logged_in && basketButton && !product.is_variant)"

--- a/resources/js/Iris/Components/ProductSoundButton.vue
+++ b/resources/js/Iris/Components/ProductSoundButton.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import { ref, onBeforeUnmount } from "vue"
+
+// ponytail: spectrum logic mirrors Components/Pure/AudioWaveform.vue; extract a composable if a third user appears
+const props = defineProps<{ src: string }>()
+
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+const isPlaying = ref(false)
+let audio: HTMLAudioElement | null = null
+let analyser: AnalyserNode | null = null
+let playbackContext: AudioContext | null = null
+let frequencyData: Uint8Array | null = null
+let rafId = 0
+
+const BAR_COUNT = 32
+
+function drawSpectrum() {
+    const canvas = canvasRef.value
+    if (!canvas || !analyser || !frequencyData) return
+
+    analyser.getByteFrequencyData(frequencyData)
+
+    const dpr = window.devicePixelRatio || 1
+    const width = canvas.clientWidth
+    const height = canvas.clientHeight
+    if (!width || !height) return
+    canvas.width = width * dpr
+    canvas.height = height * dpr
+
+    const context = canvas.getContext("2d")
+    if (!context) return
+    context.scale(dpr, dpr)
+    context.clearRect(0, 0, width, height)
+
+    const gap = 3
+    const barWidth = Math.max((width - gap * (BAR_COUNT - 1)) / BAR_COUNT, 1)
+    const usableBins = Math.floor(frequencyData.length * 0.66)
+    const binsPerBar = Math.max(1, Math.floor(usableBins / BAR_COUNT))
+
+    for (let i = 0; i < BAR_COUNT; i++) {
+        let sum = 0
+        for (let j = i * binsPerBar; j < (i + 1) * binsPerBar; j++) {
+            sum += frequencyData[j]
+        }
+        const value = sum / binsPerBar / 255
+        const barHeight = Math.max(value * height * 0.85, 4)
+        const x = i * (barWidth + gap)
+        const y = (height - barHeight) / 2
+        context.fillStyle = `hsla(${(i / BAR_COUNT) * 300}, 85%, 50%, 0.9)`
+        context.beginPath()
+        context.roundRect(x, y, barWidth, barHeight, barWidth / 2)
+        context.fill()
+    }
+}
+
+function tick() {
+    if (audio && isPlaying.value) {
+        drawSpectrum()
+        rafId = requestAnimationFrame(tick)
+    }
+}
+
+function togglePlay() {
+    if (!audio) {
+        audio = new Audio(props.src)
+        audio.crossOrigin = "anonymous"
+        audio.onended = () => {
+            isPlaying.value = false
+            cancelAnimationFrame(rafId)
+        }
+        playbackContext = new AudioContext()
+        const source = playbackContext.createMediaElementSource(audio)
+        analyser = playbackContext.createAnalyser()
+        analyser.fftSize = 256
+        analyser.smoothingTimeConstant = 0.75
+        source.connect(analyser)
+        analyser.connect(playbackContext.destination)
+        frequencyData = new Uint8Array(analyser.frequencyBinCount)
+    }
+
+    if (isPlaying.value) {
+        audio.pause()
+        isPlaying.value = false
+        cancelAnimationFrame(rafId)
+    } else {
+        playbackContext?.resume()
+        audio.play()
+        isPlaying.value = true
+        tick()
+    }
+}
+
+onBeforeUnmount(() => {
+    audio?.pause()
+    playbackContext?.close()
+    cancelAnimationFrame(rafId)
+})
+</script>
+
+<template>
+    <div>
+        <!-- Live spectrum overlay on the product image -->
+        <div v-show="isPlaying" class="absolute inset-0 z-10 flex items-end bg-white/40 pointer-events-none">
+            <canvas ref="canvasRef" class="w-full h-2/3" />
+        </div>
+
+        <!-- Circular wave play/stop button -->
+        <button
+            @click.prevent.stop="togglePlay()"
+            class="absolute left-2 bottom-2 z-20 h-10 w-10 rounded-full bg-white/90 shadow-lg flex items-center justify-center transition hover:scale-105"
+            :title="isPlaying ? 'Stop sound sample' : 'Play sound sample'"
+            aria-label="Sound sample"
+        >
+            <svg v-if="!isPlaying" viewBox="0 0 24 24" class="h-5 w-5 text-gray-700" fill="none" stroke="currentColor"
+                stroke-width="2.5" stroke-linecap="round">
+                <line x1="4" y1="9" x2="4" y2="15" />
+                <line x1="8" y1="6" x2="8" y2="18" />
+                <line x1="12" y1="3" x2="12" y2="21" />
+                <line x1="16" y1="7" x2="16" y2="17" />
+                <line x1="20" y1="10" x2="20" y2="14" />
+            </svg>
+            <svg v-else viewBox="0 0 24 24" class="h-4 w-4 text-gray-700" fill="currentColor">
+                <rect x="5" y="5" width="14" height="14" rx="2" />
+            </svg>
+        </button>
+    </div>
+</template>

--- a/routes/grp/web/models.php
+++ b/routes/grp/web/models.php
@@ -352,6 +352,7 @@ use App\Actions\Masters\MasterAsset\UpdateMasterAssetImageAlt;
 use App\Actions\Masters\MasterAsset\UpdateMasterAssetIndex;
 use App\Actions\Masters\MasterAsset\UpdateMasterProductImages;
 use App\Actions\Masters\MasterAsset\UpdateMultipleMasterProductsFamily;
+use App\Actions\Masters\MasterAsset\UploadAudioToMasterProduct;
 use App\Actions\Masters\MasterAsset\UploadImagesToMasterProduct;
 use App\Actions\Masters\MasterCollection\AttachMasterCollectionToModel;
 use App\Actions\Masters\MasterCollection\AttachModelsToMasterCollection;
@@ -675,6 +676,7 @@ Route::prefix('master-asset/{masterAsset:id}')->name('master_asset.')->group(fun
     Route::post('kill-all-rebels', KillAllMasterAssetRebelProducts::class)->name('kill_all_rebels');
     Route::patch('update-images', UpdateMasterProductImages::class)->name('update_images');
     Route::post('upload-images', UploadImagesToMasterProduct::class)->name('upload_images');
+    Route::post('upload-audio', UploadAudioToMasterProduct::class)->name('upload_audio');
     Route::delete('delete-images/{media:id}', DeleteImageFromMasterProduct::class)->name('delete_images')->withoutScopedBindings();
     Route::patch('media/{media:id}/alt', UpdateMasterAssetImageAlt::class)->name('update_image_alt')->withoutScopedBindings();
 });

--- a/routes/grp/web/models/stock/stock.php
+++ b/routes/grp/web/models/stock/stock.php
@@ -10,6 +10,7 @@ use App\Actions\Goods\TradeUnit\DeleteImageFromTradeUnit;
 use App\Actions\Goods\TradeUnit\UpdateTradeUnit;
 use App\Actions\Goods\TradeUnit\UpdateTradeUnitImageAlt;
 use App\Actions\Goods\TradeUnit\UpdateTradeUnitImages;
+use App\Actions\Goods\TradeUnit\UploadAudioToTradeUnit;
 use App\Actions\Goods\TradeUnit\UploadImagesToTradeUnit;
 use App\Actions\Helpers\Media\AttachAttachmentToModel;
 use App\Actions\Helpers\Media\DetachAttachmentFromModel;
@@ -19,6 +20,7 @@ Route::name('trade-unit.')->prefix('trade-unit/{tradeUnit:id}')->group(function 
     Route::patch('update', UpdateTradeUnit::class)->name('update')->withoutScopedBindings();
     Route::patch('update-images', UpdateTradeUnitImages::class)->name('update_images')->withoutScopedBindings();
     Route::post('upload-images', UploadImagesToTradeUnit::class)->name('upload_images');
+    Route::post('upload-audio', UploadAudioToTradeUnit::class)->name('upload_audio');
     Route::delete('detach-image/{media:id}', DeleteImageFromTradeUnit::class)->name('detach_image')->withoutScopedBindings();
     Route::patch('media/{media:id}/alt', UpdateTradeUnitImageAlt::class)->name('update_image_alt')->withoutScopedBindings();
 

--- a/routes/iris/root.php
+++ b/routes/iris/root.php
@@ -7,6 +7,7 @@
  */
 
 use App\Actions\Retina\Dropshipping\Bundle\UI\RedirectIrisToRetinaBundle;
+use App\Actions\Helpers\Media\UI\ShowIrisAudio;
 use App\Actions\Retina\Media\DownloadRetinaAttachment;
 use Illuminate\Support\Facades\Route;
 use App\Actions\Iris\UpdateIrisLocale;
@@ -72,6 +73,7 @@ Route::middleware(Sample::always())->prefix("json")
     ->group(__DIR__."/json.php");
 
 Route::patch('/locale/{locale}', UpdateIrisLocale::class)->name('locale.update');
+Route::get('audio/{media:ulid}', ShowIrisAudio::class)->name('audio');
 Route::middleware(["iris-relax-auth:retina"])->group(function () {
     Route::middleware(Sample::always())->prefix("models")
         ->name("models.")

--- a/tests/Feature/MastersTest.php
+++ b/tests/Feature/MastersTest.php
@@ -3057,3 +3057,48 @@ test('creating a master asset queues its effective cost hydration', function (Ma
             && $job->getParameters()[0]->id === $masterAsset->id
     );
 })->depends("create master family");
+
+test('upload and delete sound sample on master asset', function () {
+    $masterDepartment = ensureMasterProductCategory();
+    $masterFamily     = StoreMasterProductCategory::make()->action($masterDepartment, [
+        'code' => 'SND-FAM-'.rand(100, 999),
+        'name' => 'sound family',
+        'type' => MasterProductCategoryTypeEnum::FAMILY
+    ]);
+
+    $masterAsset = StoreMasterAsset::make()->action($masterFamily, [
+        'code'    => 'SOUND_SAMPLE_1',
+        'name'    => 'sound sample 1',
+        'is_main' => true,
+        'type'    => MasterAssetTypeEnum::RENTAL,
+        'price'   => 10,
+        'stocks'  => [],
+    ]);
+
+    $media = \App\Actions\Masters\MasterAsset\UploadAudioToMasterProduct::make()->handle($masterAsset, [
+        'audio' => \Illuminate\Http\UploadedFile::fake()->create('bowl.mp3', 100, 'audio/mpeg'),
+    ]);
+
+    $masterAsset->refresh();
+
+    expect($masterAsset->audio_id)->toBe($media->id)
+        ->and($masterAsset->audio->id)->toBe($media->id)
+        ->and($masterAsset->images()->wherePivot('scope', 'audio')->count())->toBe(1)
+        ->and($masterAsset->images()->wherePivot('sub_scope', 'audio')->first()->id)->toBe($media->id);
+
+    $bucketImages = (new class () {
+        use \App\Actions\Traits\HasBucketImages;
+    })->getImagesData($masterAsset);
+    $audioBox = collect($bucketImages)->firstWhere('column_in_db', 'audio_id');
+    expect($audioBox['type'])->toBe('audio')
+        ->and($audioBox['audio']['url'])->toContain($media->ulid);
+
+    $audioResponse = \App\Actions\Helpers\Media\UI\ShowIrisAudio::make()->asController($media);
+    expect($audioResponse->headers->get('Content-Type'))->toBe($media->mime_type);
+
+    \App\Actions\Masters\MasterAsset\DeleteImageFromMasterProduct::make()->handle($masterAsset, $media);
+    $masterAsset->refresh();
+
+    expect($masterAsset->audio_id)->toBeNull()
+        ->and($masterAsset->images()->count())->toBe(0);
+});


### PR DESCRIPTION
Closes HELP-2975.

## What
Products that make sound (gongs, singing bowls, instruments) can now carry an uploaded audio sample, shown with a frequency-spectrum player.

### Backoffice (grp)
- New **Sound sample** slot at the end of the Media tab grid (master products and trade units), empty by default.
- Upload accepts mp3/wav/ogg/m4a/aac/flac (max 50MB); renders a static rainbow amplitude waveform, click to play with live FFT spectrum animation.
- `audio_id` column added to `master_assets`, `products`, `trade_units`; propagates trade unit → master → shop products through the existing image clone pipeline. Delete/unlink works via the existing media delete flow.
- Audio media is excluded from the imgproxy-backed flat image lists.

### Webshop (iris)
- Public `GET /audio/{ulid}` route streaming the sample (audio media only, immutable cache headers).
- Product cards (Ecom1/2/3) and the product detail page get a circular wave play button — rendered **only when a sample exists**. Playing overlays a live frequency spectrum on the product image.

## Tests
- New Pest test in `MastersTest`: upload → column/pivot/bucket-slot assertions, iris audio route response, delete cleanup.
- Test DB dumps regenerated for the migration.

## Not included
- Storefront design polish beyond the card/product-page button (placement tweaks welcome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)