### PR TITLE
🔏 feat(crm): AnonymiseCustomer — GDPR erasure that keeps the ledger intact

### DIFF
--- a/app/Actions/CRM/Customer/AnonymiseCustomer.php
+++ b/app/Actions/CRM/Customer/AnonymiseCustomer.php
@@ -1,0 +1,356 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Sun, 23 Aug 2026 10:12:00 Malaysia Time, Kuala Lumpur, Malaysia
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\CRM\Customer;
+
+use App\Actions\Catalogue\Shop\Hydrators\ShopHydrateCustomers;
+use App\Actions\OrgAction;
+use App\Enums\CRM\Livechat\ChatSenderTypeEnum;
+use App\Models\Chat\ChatMessage;
+use App\Models\Chat\ChatMessageTranslation;
+use App\Models\Chat\ChatSession;
+use App\Models\Comms\EmailAddress;
+use App\Models\CRM\Customer;
+use App\Models\CRM\Prospect;
+use App\Models\CRM\WebUser;
+use App\Models\Helpers\Address;
+use App\Models\Helpers\Audit;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Redirect;
+use Lorisleiva\Actions\ActionRequest;
+use OwenIt\Auditing\Events\AuditCustom;
+
+class AnonymiseCustomer extends OrgAction
+{
+    public string $commandSignature = 'customer:anonymise {slug} {--reason=} {--keep-company-name}';
+
+    public const string ERASED = '[erased]';
+
+    public const string AUDIT_EVENT = 'anonymised';
+
+    public const string DELETED_CAUSE = 'anonymised';
+
+    private Customer $customer;
+
+    public function handle(Customer $customer, string $reason, bool $keepCompanyName = false): Customer
+    {
+        if (static::isAnonymised($customer)) {
+            return $customer;
+        }
+
+        $webUserIds = $customer->webUsers()->withTrashed()->pluck('id');
+
+        DB::transaction(fn () => Customer::withoutAuditing(function () use ($customer, $keepCompanyName, $webUserIds) {
+            $this->anonymiseAddresses($customer);
+            $this->anonymiseCustomerRecord($customer, $keepCompanyName);
+            $this->anonymiseCustomerClients($customer);
+            $this->anonymiseWebUsers($customer);
+            $this->anonymiseChats($webUserIds->all());
+            $this->anonymiseDispatchedEmailRecipients($customer, $webUserIds->all());
+            $this->unsubscribeFromAllComms($customer);
+            $this->scrubEarlierAudits($customer, $webUserIds->all());
+
+            $customer->delete();
+        }, globally: true));
+
+        $customer->unsearchable();
+        $this->writeErasureAudit($customer, $reason, $keepCompanyName);
+
+        ShopHydrateCustomers::dispatch($customer->shop);
+
+        return $customer;
+    }
+
+    public static function isAnonymised(Customer $customer): bool
+    {
+        return $customer->trashed() && Arr::get($customer->data, 'deleted.cause') === self::DELETED_CAUSE;
+    }
+
+    private function anonymiseCustomerRecord(Customer $customer, bool $keepCompanyName): void
+    {
+        $location    = $customer->location;
+        $location[2] = '';
+
+        if (!$keepCompanyName) {
+            $customer->taxNumber()->delete();
+        }
+
+        $customer->forceFill([
+            'name'                     => 'Anonymised '.$customer->reference,
+            'contact_name'             => null,
+            'company_name'             => $keepCompanyName ? $customer->company_name : null,
+            'fiscal_name'              => $keepCompanyName ? $customer->fiscal_name : null,
+            'email'                    => null,
+            'phone'                    => null,
+            'identity_document_type'   => null,
+            'identity_document_number' => null,
+            'contact_website'          => null,
+            'internal_notes'           => null,
+            'warehouse_internal_notes' => null,
+            'warehouse_public_notes'   => null,
+            'rejected_notes'           => null,
+            'accounting_reference'     => null,
+            'contact_name_components'  => [],
+            'location'                 => $location,
+            'address_id'               => null,
+            'delivery_address_id'      => null,
+            'migration_data'           => [],
+            'data'                     => ['deleted' => ['cause' => self::DELETED_CAUSE, 'at' => now()->toIso8601String()]],
+        ]);
+        $customer->syncSearchableText();
+        $customer->saveQuietly();
+    }
+
+    private function anonymiseAddresses(Model $model): void
+    {
+        foreach ($model->addresses as $address) {
+            $isSharedWithOtherModels = DB::table('model_has_addresses')
+                ->where('address_id', $address->id)
+                ->where(fn ($query) => $query->where('model_type', '!=', $model->getMorphClass())->orWhere('model_id', '!=', $model->id))
+                ->exists();
+
+            if (!$isSharedWithOtherModels) {
+                $this->wipeAddress($address);
+            }
+        }
+        $model->addresses()->detach();
+    }
+
+    private function wipeAddress(Address $address): void
+    {
+        $address->forceFill([
+            'address_line_1'      => null,
+            'address_line_2'      => null,
+            'sorting_code'        => null,
+            'postal_code'         => null,
+            'dependent_locality'  => null,
+            'locality'            => null,
+            'administrative_area' => null,
+            'latitude'            => null,
+            'longitude'           => null,
+            'geocoding_metadata'  => null,
+            'checksum'            => null,
+        ])->saveQuietly();
+    }
+
+    private function anonymiseCustomerClients(Customer $customer): void
+    {
+        foreach ($customer->clients()->withTrashed()->get() as $client) {
+            $this->anonymiseAddresses($client);
+            $client->forceFill([
+                'name'                => 'Anonymised '.$client->reference,
+                'contact_name'        => null,
+                'company_name'        => null,
+                'email'               => null,
+                'phone'               => null,
+                'address_id'          => null,
+                'delivery_address_id' => null,
+                'location'            => [],
+            ])->saveQuietly();
+        }
+    }
+
+    private function anonymiseWebUsers(Customer $customer): void
+    {
+        foreach ($customer->webUsers()->withTrashed()->get() as $webUser) {
+            $webUser->tokens()->delete();
+            DB::table('web_user_password_resets')->where('web_user_id', $webUser->id)->delete();
+            DB::table('web_user_logins')->where('web_user_id', $webUser->id)->update(['ip_address' => null]);
+
+            $webUser->forceFill([
+                'username'          => 'gdpr-'.$webUser->id,
+                'email'             => 'anonymised-'.$webUser->id.'@example.invalid',
+                'contact_name'      => null,
+                'about'             => null,
+                'password'          => null,
+                'remember_token'    => null,
+                'email_verified_at' => null,
+                'data'              => [],
+            ])->saveQuietly();
+
+            if (!$webUser->trashed()) {
+                $webUser->delete();
+            }
+        }
+    }
+
+    private function anonymiseChats(array $webUserIds): void
+    {
+        if (!$webUserIds) {
+            return;
+        }
+
+        $sessionIds = ChatSession::whereIn('web_user_id', $webUserIds)->pluck('id');
+        if ($sessionIds->isEmpty()) {
+            return;
+        }
+
+        $messages = ChatMessage::withTrashed()
+            ->whereIn('chat_session_id', $sessionIds)
+            ->where('sender_type', ChatSenderTypeEnum::USER);
+
+        ChatMessageTranslation::whereIn('chat_message_id', (clone $messages)->pluck('id'))
+            ->update(['translated_text' => self::ERASED]);
+
+        $messages->update([
+            'message_text'  => self::ERASED,
+            'original_text' => null,
+            'metadata'      => null,
+        ]);
+
+        ChatSession::whereIn('id', $sessionIds)->update(['metadata' => null, 'guest_identifier' => null]);
+    }
+
+    private function anonymiseDispatchedEmailRecipients(Customer $customer, array $webUserIds): void
+    {
+        $dispatchedEmailIds = $customer->dispatchedEmails()->pluck('dispatched_emails.id');
+
+        foreach (['mailshot_recipients', 'email_bulk_run_recipients'] as $table) {
+            DB::table($table)->whereIn('dispatched_email_id', $dispatchedEmailIds)->update(['recipient_name' => null]);
+        }
+
+        $emailAddressIds = DB::table('dispatched_emails')->whereIn('id', $dispatchedEmailIds)->whereNotNull('email_address_id')->distinct()->pluck('email_address_id');
+        foreach (EmailAddress::whereIn('id', $emailAddressIds)->get() as $emailAddress) {
+            if ($this->isEmailStillInUse($emailAddress->email, $customer)) {
+                continue;
+            }
+            $emailAddress->updateQuietly(['email' => 'anonymised-'.$customer->id.'-'.$emailAddress->id.'@example.invalid']);
+        }
+    }
+
+    private function isEmailStillInUse(string $email, Customer $customer): bool
+    {
+        return Customer::where('email', $email)->where('id', '!=', $customer->id)->exists()
+            || WebUser::where('email', $email)->exists()
+            || Prospect::where('email', $email)->exists();
+    }
+
+    private function unsubscribeFromAllComms(Customer $customer): void
+    {
+        $comms = $customer->comms;
+        if (!$comms) {
+            return;
+        }
+
+        $unsubscribed = [];
+        foreach (Arr::where($comms->getAttributes(), fn ($value, string $key) => str_starts_with($key, 'is_subscribed_to_')) as $column => $value) {
+            $channel                                        = substr($column, strlen('is_subscribed_to_'));
+            $unsubscribed[$column]                          = false;
+            $unsubscribed[$channel.'_unsubscribed_at']      = now();
+            $unsubscribed[$channel.'_unsubscribed_origin_type'] = 'Customer';
+        }
+        $comms->forceFill($unsubscribed)->saveQuietly();
+    }
+
+    private function scrubEarlierAudits(Customer $customer, array $webUserIds): void
+    {
+        Audit::where(function ($query) use ($customer, $webUserIds) {
+            $query->where(fn ($q) => $q->where('auditable_type', 'Customer')->where('auditable_id', $customer->id))
+                ->orWhere(fn ($q) => $q->where('auditable_type', 'WebUser')->whereIn('auditable_id', $webUserIds))
+                ->orWhere(fn ($q) => $q->where('auditable_type', 'CustomerClient')->whereIn('auditable_id', $customer->clients()->withTrashed()->pluck('id')))
+                ->orWhere(fn ($q) => $q->where('user_type', 'WebUser')->whereIn('user_id', $webUserIds));
+        })->update([
+            'old_values' => DB::raw("'{}'::jsonb"),
+            'new_values' => DB::raw("'{}'::jsonb"),
+            'ip_address' => null,
+            'user_agent' => null,
+        ]);
+    }
+
+    private function writeErasureAudit(Customer $customer, string $reason, bool $keepCompanyName): void
+    {
+        $customer->auditEvent     = self::AUDIT_EVENT;
+        $customer->isCustomEvent  = true;
+        $customer->auditCustomOld = [];
+        $customer->auditCustomNew = [
+            'reason'            => $reason,
+            'keep_company_name' => $keepCompanyName,
+            'anonymised_at'     => now()->toIso8601String(),
+        ];
+        Event::dispatch(new AuditCustom($customer));
+    }
+
+    public function authorize(ActionRequest $request): bool
+    {
+        if ($this->asAction) {
+            return true;
+        }
+
+        return $request->user()->authTo("supervisor-crm.{$this->customer->shop_id}");
+    }
+
+    public function rules(): array
+    {
+        return [
+            'reason'            => ['required', 'string', 'max:1000'],
+            'reference'         => ['required', 'string', 'in:'.$this->customer->reference],
+            'keep_company_name' => ['sometimes', 'boolean'],
+        ];
+    }
+
+    public function asController(Customer $customer, ActionRequest $request): Customer
+    {
+        $this->customer = $customer;
+        $this->initialisationFromShop($customer->shop, $request);
+
+        return $this->handle($customer, $this->validatedData['reason'], (bool)Arr::get($this->validatedData, 'keep_company_name', false));
+    }
+
+    public function htmlResponse(Customer $customer): RedirectResponse
+    {
+        return Redirect::route('grp.org.shops.show.crm.customers.index', [
+            $customer->organisation->slug,
+            $customer->shop->slug,
+        ]);
+    }
+
+    public function action(Customer $customer, string $reason, bool $keepCompanyName = false): Customer
+    {
+        $this->asAction = true;
+        $this->customer = $customer;
+        $this->initialisationFromShop($customer->shop, [
+            'reason'            => $reason,
+            'reference'         => $customer->reference,
+            'keep_company_name' => $keepCompanyName,
+        ]);
+
+        return $this->handle($customer, $reason, $keepCompanyName);
+    }
+
+    public function asCommand(Command $command): int
+    {
+        $customer = Customer::withTrashed()->where('slug', $command->argument('slug'))->first();
+        if (!$customer) {
+            $command->error('Customer not found');
+
+            return 1;
+        }
+        if (static::isAnonymised($customer)) {
+            $command->info('Customer '.$customer->reference.' is already anonymised');
+
+            return 0;
+        }
+
+        $reason = $command->option('reason') ?: 'GDPR erasure request';
+
+        if (!$command->option('no-interaction') && !$command->confirm("Anonymise customer {$customer->reference} ({$customer->name}, {$customer->shop->slug})? This can not be undone.")) {
+            return 1;
+        }
+
+        $this->handle($customer, $reason, (bool)$command->option('keep-company-name'));
+
+        $command->info('Customer '.$customer->reference.' anonymised and soft deleted');
+
+        return 0;
+    }
+}

--- a/app/Actions/CRM/Customer/UI/ShowCustomer.php
+++ b/app/Actions/CRM/Customer/UI/ShowCustomer.php
@@ -13,6 +13,7 @@ use App\Actions\Accounting\Payment\UI\IndexPayments;
 use App\Actions\Catalogue\Shop\UI\ShowShop;
 use App\Actions\Comms\BackInStockReminder\UI\IndexCustomerBackInStockReminders;
 use App\Actions\Comms\DispatchedEmail\UI\IndexDispatchedEmails;
+use App\Actions\CRM\Customer\AnonymiseCustomer;
 use App\Actions\CRM\Customer\DeleteCustomer;
 use App\Actions\CRM\Favourite\UI\IndexCustomerFavourites;
 use App\Actions\Discounts\Offer\UI\IndexOffers;
@@ -159,6 +160,20 @@ class ShowCustomer extends OrgAction
                                 'name'       => 'grp.models.customer.delete',
                                 'parameters' => ['customer' => $customer->id],
                                 'method'     => 'delete',
+                            ]
+                        ] : false,
+                        $this->isSupervisor && !AnonymiseCustomer::isAnonymised($customer) ? [
+                            'key'     => 'anonymise_customer',
+                            'type'    => 'button',
+                            'style'   => 'delete',
+                            'icon'    => 'fal fa-user-secret',
+                            'label'   => __('Anonymise (GDPR)'),
+                            'tooltip' => __('Erase personal data and soft delete the customer. Invoices and orders stay.'),
+                            'reference' => $customer->reference,
+                            'route'   => [
+                                'name'       => 'grp.models.customer.anonymise',
+                                'parameters' => ['customer' => $customer->id],
+                                'method'     => 'post',
                             ]
                         ] : false,
                     ])),

--- a/resources/js/Pages/Grp/Org/Shop/CRM/Customer.vue
+++ b/resources/js/Pages/Grp/Org/Shop/CRM/Customer.vue
@@ -30,7 +30,7 @@ import ModalConfirmationDelete from "@/Components/Utils/ModalConfirmationDelete.
 import { trans } from "laravel-vue-i18n"
 import TableHistories from "@/Components/Tables/Grp/Helpers/TableHistories.vue"
 import { library } from "@fortawesome/fontawesome-svg-core"
-import { faCodeCommit, faUsers, faGlobe, faGraduationCap, faMoneyBill, faPaperclip, faPaperPlane, faStickyNote, faTags, faCube, faCodeBranch, faShoppingCart, faHeart, faQuestionCircle, faLightbulbOn, faRoute } from "@fal"
+import { faCodeCommit, faUsers, faGlobe, faGraduationCap, faMoneyBill, faPaperclip, faPaperPlane, faStickyNote, faTags, faCube, faCodeBranch, faShoppingCart, faHeart, faQuestionCircle, faLightbulbOn, faRoute, faUserSecret } from "@fal"
 import { routeType } from "@/types/route"
 import { AddressManagement } from "@/types/PureComponent/Address"
 import TableCreditTransactions from "@/Components/Tables/Grp/Org/Accounting/TableCreditTransactions.vue"
@@ -42,8 +42,10 @@ import ModalCreateCustomerOffers from "@/Components/Offers/ModalCreateCustomerOf
 import SelectableCardGrid from "@/Components/Utils/SelectableCardGrid.vue"
 import { useForm } from "@inertiajs/vue3"
 import LoadingOverlay from "@/Components/Utils/LoadingOverlay.vue"
+import PureInput from "@/Components/Pure/PureInput.vue"
+import PureTextarea from "@/Components/Pure/PureTextarea.vue"
 
-library.add(faStickyNote, faUsers, faGlobe, faMoneyBill, faGraduationCap, faTags, faCodeCommit, faPaperclip, faPaperPlane, faCube, faCodeBranch, faShoppingCart, faHeart, faQuestionCircle, faLightbulbOn, faRoute)
+library.add(faStickyNote, faUsers, faGlobe, faMoneyBill, faGraduationCap, faTags, faCodeCommit, faPaperclip, faPaperPlane, faCube, faCodeBranch, faShoppingCart, faHeart, faQuestionCircle, faLightbulbOn, faRoute, faUserSecret)
 
 
 const props = defineProps<{
@@ -107,6 +109,21 @@ const isModalUploadOpen = ref(false)
 const isOrderModalOpen = ref(false)
 const handleTabUpdate = (tabSlug: string) => useTabChange(tabSlug, currentTab)
 
+const isAnonymiseModalOpen = ref(false)
+const anonymiseForm = useForm({
+    reason: "",
+    reference: "",
+    keep_company_name: false
+})
+const submitAnonymise = (routeToPost: routeType) => {
+    anonymiseForm.post(route(routeToPost.name, routeToPost.parameters), {
+        onSuccess: () => {
+            isAnonymiseModalOpen.value = false
+            anonymiseForm.reset()
+        }
+    })
+}
+
 const orderForm = useForm({
     sales_channel_id: null as number | null
 })
@@ -156,6 +173,36 @@ const layout = inject('layout')
                         @click="changeModel" />
                 </template>
             </ModalConfirmationDelete>
+        </template>
+        <template #button-anonymise-customer="{ action }">
+            <div>
+                <Button :style="'delete'" :icon="action.icon" :label="action.label" v-tooltip="action.tooltip"
+                    @click="isAnonymiseModalOpen = true" />
+                <Modal :isOpen="isAnonymiseModalOpen" @onClose="isAnonymiseModalOpen = false" width="w-full max-w-lg">
+                    <div class="space-y-4">
+                        <h3 class="text-base font-semibold">{{ trans("Anonymise customer") }} {{ action.reference }}</h3>
+                        <p class="text-sm text-gray-600">
+                            {{ trans("Personal data (names, email, phone, addresses, notes, login) will be erased and the customer soft deleted. Invoices, orders and payments are kept. This can not be undone.") }}
+                        </p>
+                        <PureTextarea v-model="anonymiseForm.reason" :placeholder="trans('Reason (e.g. erasure request received on ...)')" :rows="3" />
+                        <p v-if="anonymiseForm.errors.reason" class="text-xs text-red-500">{{ anonymiseForm.errors.reason }}</p>
+                        <label class="flex items-center gap-2 text-sm">
+                            <input type="checkbox" v-model="anonymiseForm.keep_company_name" />
+                            {{ trans("Keep company name and tax number (business customer)") }}
+                        </label>
+                        <div>
+                            <p class="text-sm mb-1">{{ trans("Type the customer reference") }} <strong>{{ action.reference }}</strong> {{ trans("to confirm") }}</p>
+                            <PureInput v-model="anonymiseForm.reference" :placeholder="action.reference" />
+                        </div>
+                        <div class="flex justify-end gap-2">
+                            <Button type="secondary" :label="trans('Cancel')" @click="isAnonymiseModalOpen = false" />
+                            <Button type="delete" :label="trans('Anonymise')" :loading="anonymiseForm.processing"
+                                :disabled="!anonymiseForm.reason || anonymiseForm.reference !== action.reference"
+                                @click="submitAnonymise(action.route)" />
+                        </div>
+                    </div>
+                </Modal>
+            </div>
         </template>
         <template #other>
             <ModalCreateCustomerOffers v-if="currentTab === 'offers'" :shop_data="props.shop_data" :customer_id="props.shop_data.customer_id" />

--- a/routes/grp/web/models.php
+++ b/routes/grp/web/models.php
@@ -103,6 +103,7 @@ use App\Actions\Comms\OutboxHasSubscribers\DeleteOutboxHasSubscriber;
 use App\Actions\Comms\OutboxHasSubscribers\StoreManyOutboxHasSubscriber;
 use App\Actions\CRM\Customer\AddDeliveryAddressToCustomer;
 use App\Actions\CRM\Customer\ApproveCustomer;
+use App\Actions\CRM\Customer\AnonymiseCustomer;
 use App\Actions\CRM\Customer\DeleteCustomer;
 use App\Actions\CRM\Customer\DeleteCustomerDeliveryAddress;
 use App\Actions\CRM\Customer\RejectCustomer;
@@ -1186,6 +1187,7 @@ Route::delete('/web-user/{webUser:id}', DeleteWebUser::class)->name('web-user.de
 Route::name('customer.')->prefix('customer/{customer:id}')->group(function () {
     Route::post('', [StoreWebUser::class, 'inCustomer'])->name('web-user.store');
     Route::delete('', DeleteCustomer::class)->name('delete');
+    Route::post('anonymise', AnonymiseCustomer::class)->name('anonymise');
     Route::post('delivery-address', AddDeliveryAddressToCustomer::class)->name('address.store');
     Route::patch('address/update', UpdateCustomerAddress::class)->name('address.update');
     Route::delete('address/{address:id}/delete', [DeleteCustomerDeliveryAddress::class, 'inCustomer'])->name('delivery-address.delete')->withoutScopedBindings();

--- a/tests/Feature/CrmTest.php
+++ b/tests/Feature/CrmTest.php
@@ -14,7 +14,9 @@ use App\Actions\Catalogue\Shop\UpdateShop;
 use App\Actions\Comms\BackInStockReminder\DeleteBackInStockReminder;
 use App\Actions\Comms\BackInStockReminder\StoreBackInStockReminder;
 use App\Actions\Comms\Mailshot\StoreMailshot;
+use App\Actions\Accounting\Invoice\StoreInvoice;
 use App\Actions\CRM\Customer\AddDeliveryAddressToCustomer;
+use App\Actions\CRM\Customer\AnonymiseCustomer;
 use App\Actions\CRM\Customer\DeleteCustomer;
 use App\Actions\CRM\Customer\DeleteCustomerDeliveryAddress;
 use App\Actions\CRM\Customer\HydrateCustomers;
@@ -72,7 +74,9 @@ use App\Models\Analytics\AikuScopedSection;
 use App\Models\Comms\BackInStockReminder;
 use App\Models\Comms\Mailshot;
 use App\Models\Comms\Outbox;
+use App\Models\Accounting\Invoice;
 use App\Models\CRM\Customer;
+use App\Models\Helpers\Audit;
 use App\Models\CRM\CustomerNote;
 use App\Models\CRM\Favourite;
 use App\Models\CRM\Poll;
@@ -86,6 +90,7 @@ use App\Models\Web\Website;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Validation\ValidationException;
@@ -1485,5 +1490,124 @@ describe('EU VAT re-validation (HELP-2374)', function () {
         ValidateEuropeanTaxNumber::make()->handle($taxNumber, null, false);
 
         Queue::assertNothingPushed();
+    });
+});
+
+describe('anonymise customer (GDPR erasure)', function () {
+    beforeEach(function () {
+        $this->erasureEmail    = 'jane.'.uniqid().'@example.com';
+        $this->erasureUsername = 'jane-'.uniqid();
+        $this->erasureCustomer = StoreCustomer::make()->action($this->shop, array_merge(Customer::factory()->definition(), [
+            'contact_name' => 'Jane Erasure',
+            'email'        => $this->erasureEmail,
+            'phone'        => '+441234567890',
+        ]));
+        $this->erasureWebUser = StoreWebUser::make()->action($this->erasureCustomer, [
+            'email'    => $this->erasureEmail,
+            'username' => $this->erasureUsername,
+            'password' => 'password',
+        ]);
+        $this->erasureOrder   = StoreOrder::make()->action($this->erasureCustomer, []);
+        $this->erasureInvoice = StoreInvoice::make()->action($this->erasureCustomer, Invoice::factory()->definition());
+        $this->erasureAddressId = $this->erasureCustomer->address_id;
+
+        $this->erasureCustomer = AnonymiseCustomer::make()->action($this->erasureCustomer, 'Erasure request by email', false);
+        $this->erasureCustomer->refresh();
+    });
+
+    test('personal fields are erased and the customer is soft deleted', function () {
+        $customer = $this->erasureCustomer;
+
+        expect($customer->trashed())->toBeTrue()
+            ->and($customer->name)->toBe('Anonymised '.$customer->reference)
+            ->and($customer->contact_name)->toBeNull()
+            ->and($customer->company_name)->toBeNull()
+            ->and($customer->email)->toBeNull()
+            ->and($customer->phone)->toBeNull()
+            ->and($customer->identity_document_number)->toBeNull()
+            ->and($customer->contact_website)->toBeNull()
+            ->and($customer->address_id)->toBeNull()
+            ->and($customer->addresses()->count())->toBe(0)
+            ->and($customer->searchable_text)->not->toContain('jane')
+            ->and($customer->reference)->not->toBeNull()
+            ->and($customer->shop_id)->toBe($this->shop->id)
+            ->and(Arr::get($customer->data, 'deleted.cause'))->toBe('anonymised');
+
+        $address = \App\Models\Helpers\Address::find($this->erasureAddressId);
+        expect($address->address_line_1)->toBeNull()
+            ->and($address->postal_code)->toBeNull()
+            ->and($address->country_id)->not->toBeNull();
+    });
+
+    test('invoices and orders stay linked and untouched', function () {
+        $invoice = Invoice::find($this->erasureInvoice->id);
+        $order   = Order::find($this->erasureOrder->id);
+
+        expect($invoice->customer_id)->toBe($this->erasureCustomer->id)
+            ->and($invoice->total_amount)->toBe($this->erasureInvoice->total_amount)
+            ->and($invoice->deleted_at)->toBeNull()
+            ->and($order->customer_id)->toBe($this->erasureCustomer->id)
+            ->and($order->deleted_at)->toBeNull()
+            ->and($this->erasureCustomer->invoices()->count())->toBe(1);
+    });
+
+    test('web user is anonymised, soft deleted and can not log in', function () {
+        $webUser = WebUser::withTrashed()->find($this->erasureWebUser->id);
+
+        expect($webUser->trashed())->toBeTrue()
+            ->and($webUser->username)->toBe('gdpr-'.$webUser->id)
+            ->and($webUser->email)->toBe('anonymised-'.$webUser->id.'@example.invalid')
+            ->and($webUser->contact_name)->toBeNull()
+            ->and($webUser->password)->toBeNull()
+            ->and(Auth::guard('retina')->attempt(['username' => $this->erasureUsername, 'password' => 'password']))->toBeFalse()
+            ->and(Auth::guard('retina')->attempt(['username' => $webUser->username, 'password' => 'password']))->toBeFalse();
+    });
+
+    test('the old email and username can register again', function () {
+        $customer = StoreCustomer::make()->action($this->shop, array_merge(Customer::factory()->definition(), [
+            'contact_name' => 'Jane Again',
+            'email'        => $this->erasureEmail,
+        ]));
+        $webUser  = StoreWebUser::make()->action($customer, [
+            'email'    => $this->erasureEmail,
+            'username' => $this->erasureUsername,
+            'password' => 'password',
+        ]);
+
+        expect($customer->email)->toBe($this->erasureEmail)
+            ->and($webUser->username)->toBe($this->erasureUsername);
+    });
+
+    test('audit records who, when and why without the erased values', function () {
+        $audit = Audit::where('auditable_type', 'Customer')
+            ->where('auditable_id', $this->erasureCustomer->id)
+            ->where('event', AnonymiseCustomer::AUDIT_EVENT)
+            ->first();
+
+        expect($audit)->not->toBeNull()
+            ->and($audit->new_values['reason'])->toBe('Erasure request by email')
+            ->and(json_encode($audit->old_values).json_encode($audit->new_values))->not->toContain('jane');
+
+        $leakedAudits = Audit::where('auditable_type', 'Customer')
+            ->where('auditable_id', $this->erasureCustomer->id)
+            ->get()
+            ->filter(fn (Audit $audit) => str_contains(json_encode($audit->old_values).json_encode($audit->new_values), 'jane'));
+        expect($leakedAudits)->toBeEmpty();
+    });
+
+    test('customer is no longer found by search', function () {
+        Config::set('scout.driver', 'collection');
+
+        expect(Customer::search($this->erasureEmail)->get())->toBeEmpty()
+            ->and(Customer::search('Jane Erasure')->get())->toBeEmpty();
+    });
+
+    test('a second run is a no-op', function () {
+        $auditsBefore = Audit::where('auditable_type', 'Customer')->where('auditable_id', $this->erasureCustomer->id)->count();
+
+        $customer = AnonymiseCustomer::make()->action($this->erasureCustomer, 'again', false);
+
+        expect($customer->trashed())->toBeTrue()
+            ->and(Audit::where('auditable_type', 'Customer')->where('auditable_id', $this->erasureCustomer->id)->count())->toBe($auditsBefore);
     });
 });


### PR DESCRIPTION
## What

`App\Actions\CRM\Customer\AnonymiseCustomer` — a right-to-erasure path. One DB transaction, auditing disabled while it runs, then a single custom audit entry. Replaces the current "DeleteCustomer + hand SQL UPDATE" pattern.

Also: Artisan `customer:anonymise`, a guarded **Anonymise (GDPR)** button on the grp customer page (supervisor-crm only, reason required, must type the customer reference), and 7 tests appended to `tests/Feature/CrmTest.php`.

INI-1943 (`5df86bae60`, partial unique indexes on `web_users`) is already on `main`; this PR relies on it for re-registration and does not duplicate it.

## Touched (erased / overwritten)

| table | columns |
|---|---|
| `customers` | `name` → `Anonymised {reference}`; `contact_name`, `email`, `phone`, `identity_document_type`, `identity_document_number`, `contact_website`, `internal_notes`, `warehouse_internal_notes`, `warehouse_public_notes`, `rejected_notes`, `accounting_reference` → NULL; `company_name`, `fiscal_name` → NULL unless `keep_company_name`; `contact_name_components`, `migration_data` → `{}`; `data` → `{"deleted":{"cause":"anonymised","at":…}}`; `location[2]` (locality) → `''`; `address_id`, `delivery_address_id` → NULL; `searchable_text` rebuilt; `deleted_at` set (soft delete) |
| `addresses` (rows attached only to this customer / its clients) | `address_line_1/2`, `sorting_code`, `postal_code`, `dependent_locality`, `locality`, `administrative_area`, `latitude`, `longitude`, `geocoding_metadata`, `checksum` → NULL. `country_id/country_code` kept. Addresses also attached to another model are left alone. |
| `model_has_addresses` | customer + client pivots detached |
| `tax_numbers` | soft deleted unless `keep_company_name` |
| `customer_clients` | `name` → `Anonymised {reference}`; `contact_name`, `company_name`, `email`, `phone`, `address_id`, `delivery_address_id` → NULL; `location` → `[]` |
| `web_users` | `username` → `gdpr-{id}`, `email` → `anonymised-{id}@example.invalid`; `contact_name`, `about`, `password`, `remember_token`, `email_verified_at` → NULL; `data` → `{}`; soft deleted |
| `personal_access_tokens` | web user tokens deleted |
| `web_user_password_resets` | rows deleted |
| `web_user_logins` | `ip_address` → NULL |
| `chat_messages` (sender = this web user) / `chat_message_translations` | text → `[erased]`, `original_text`, `metadata` → NULL |
| `chat_sessions` (this web user) | `metadata`, `guest_identifier` → NULL |
| `mailshot_recipients`, `email_bulk_run_recipients` | `recipient_name` → NULL for this customer's dispatched emails |
| `email_addresses` | `email` → `anonymised-{customer}-{id}@example.invalid` when no other customer / web user / prospect still uses that address |
| `customer_comms` | every `is_subscribed_to_*` → false, `*_unsubscribed_at` → now |
| `audits` (earlier rows for this Customer / its WebUsers / CustomerClients, and rows acted by these web users) | `old_values`, `new_values` → `{}`; `ip_address`, `user_agent` → NULL. New row `event=anonymised` with `{reason, keep_company_name, anonymised_at}` only. |
| Typesense | customer removed from the index |

## Deliberately left alone

`invoices` (incl. their own fixed address rows), `orders`, `transactions`, `payments`, `credit_transactions`, `stock movements`, `delivery_notes`, `customer_stats` and all time series, `reviews`, `poll_replies`, `dispatched_emails` rows and their stats, `customer_sales_channels` / portfolios, `customers.reference / slug / shop_id / source_id`, media/attachments.

## Prod runbook

```bash
php artisan customer:anonymise {customer-slug} --reason="Erasure request ref XYZ, received 2026-08-20"
php artisan customer:anonymise {customer-slug} --reason="…" --keep-company-name   # business customer: keep company/fiscal name + VAT number
```

Interactive confirm unless `--no-interaction`. Finds soft-deleted customers too; second run on an already anonymised customer is a no-op.

## Tests

`TEST_TOKEN=gdpr$RANDOM php -d xdebug.mode=off vendor/bin/pest tests/Feature/CrmTest.php --filter=anonymise` — 7 passed (40 assertions): fields erased, invoices/orders untouched and linked, web user anonymised + soft deleted + cannot log in, old email/username re-registers, audit without erased values (earlier audits scrubbed), not in search, idempotent.

## Not in this PR

Customer/web-user avatar media, `prospects` matched to this customer (separate model, own erasure), Aurora source rows. Vue change not type-checked with a build.
