### PR TITLE
✨ SKO barcode scanner for warehouse checks and reassignment

### DIFF
--- a/app/Actions/Dispatching/DeliveryNoteItem/WithScannedDeliveryNoteItemPicking.php
+++ b/app/Actions/Dispatching/DeliveryNoteItem/WithScannedDeliveryNoteItemPicking.php
@@ -113,13 +113,15 @@ trait WithScannedDeliveryNoteItemPicking
 
         $modelData = [
             'location_org_stock_id' => $location->id,
-            'quantity'              => $quantityToPick,
             'picker_user_id'        => $user->id,
         ];
 
         if ($picking) {
             data_set($modelData, 'picking_id', $picking->id);
+            $quantityToPick += $picking->quantity;
         }
+
+        data_set($modelData, 'quantity', $quantityToPick);
 
         UpsertPicking::make()->action($deliveryNoteItem, $user, $modelData);
 

--- a/app/Actions/Dispatching/DeliveryNoteItem/WithScannedDeliveryNoteItemPicking.php
+++ b/app/Actions/Dispatching/DeliveryNoteItem/WithScannedDeliveryNoteItemPicking.php
@@ -8,9 +8,10 @@
 
 namespace App\Actions\Dispatching\DeliveryNoteItem;
 
-use App\Actions\Dispatching\Picking\StorePicking;
+use App\Actions\Dispatching\Picking\UpsertPicking;
 use App\Enums\Catalogue\Shop\ShopTypeEnum;
 use App\Models\Dispatching\DeliveryNoteItem;
+use App\Models\Dispatching\Picking;
 use App\Models\SysAdmin\User;
 use Illuminate\Support\Facades\DB;
 
@@ -74,7 +75,9 @@ trait WithScannedDeliveryNoteItemPicking
             ->select([
                 'location_org_stocks.id',
                 'location_org_stocks.quantity',
+                'location_org_stocks.org_stock_id',
                 'locations.code as location_code',
+                'locations.id as location_id'
             ])
             ->get();
 
@@ -103,11 +106,22 @@ trait WithScannedDeliveryNoteItemPicking
             return 0;
         }
 
-        StorePicking::make()->action($deliveryNoteItem, $user, [
+        $picking = Picking::where('delivery_note_item_id', $deliveryNoteItem->id)
+                        ->where('location_id', $location->location_id)
+                        ->where('org_stock_id', $location->org_stock_id)
+                        ->first();
+
+        $modelData = [
             'location_org_stock_id' => $location->id,
             'quantity'              => $quantityToPick,
             'picker_user_id'        => $user->id,
-        ]);
+        ];
+
+        if ($picking) {
+            data_set($modelData, 'picking_id', $picking->id);
+        }
+
+        UpsertPicking::make()->action($deliveryNoteItem, $user, $modelData);
 
         return $quantityToPick;
     }

--- a/app/Actions/Dispatching/Picking/UpsertPicking.php
+++ b/app/Actions/Dispatching/Picking/UpsertPicking.php
@@ -104,5 +104,15 @@ class UpsertPicking extends OrgAction
         $this->handle($deliveryNoteItem, $locationOrgStock, $this->validatedData);
     }
 
+    public function action(DeliveryNoteItem $deliveryNoteItem, User $user, array $modelData): void
+    {
+        $this->user             = $user;
+        $this->deliveryNoteItem = $deliveryNoteItem;
+        $this->initialisationFromShop($deliveryNoteItem->shop, $modelData);
+        $locationOrgStock = LocationOrgStock::find($this->validatedData['location_org_stock_id']);
+
+        $this->handle($deliveryNoteItem, $locationOrgStock, $this->validatedData);
+    }
+
 
 }

--- a/app/Actions/Inventory/OrgStock/AssignSkoBarcodeToOrgStock.php
+++ b/app/Actions/Inventory/OrgStock/AssignSkoBarcodeToOrgStock.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Wed, 02 Sep 2026, Kuala Lumpur, Malaysia
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\Inventory\OrgStock;
+
+use App\Actions\Inventory\OrgStock\Json\ScanSkoBarcode;
+use App\Actions\OrgAction;
+use App\Enums\SysAdmin\Authorisation\WarehousePermissionsEnum;
+use App\Models\Inventory\OrgStock;
+use App\Models\Inventory\Warehouse;
+use App\Models\SysAdmin\Organisation;
+use Illuminate\Support\Facades\DB;
+use Lorisleiva\Actions\ActionRequest;
+
+/**
+ * The label in the scanner's hand is the truth: whatever org stock carried this SKO barcode before
+ * gives it up, and the target takes it, replacing any SKO barcode it had. Both writes go through
+ * UpdateOrgStock so the stock and every sibling organisation follow, with history.
+ */
+class AssignSkoBarcodeToOrgStock extends OrgAction
+{
+    public function handle(OrgStock $orgStock, string $barcode): OrgStock
+    {
+        $barcode = trim($barcode);
+
+        return DB::transaction(function () use ($orgStock, $barcode) {
+            $holders = OrgStock::where('group_id', $orgStock->group_id)
+                ->where('barcode', $barcode)
+                ->where('id', '!=', $orgStock->id)
+                ->where(fn ($query) => $query->whereNull('stock_id')->orWhere('stock_id', '!=', $orgStock->stock_id))
+                ->get();
+
+            foreach ($holders as $holder) {
+                if ($holder->refresh()->barcode === $barcode) {
+                    UpdateOrgStock::make()->action($holder, ['barcode' => null]);
+                }
+            }
+
+            return UpdateOrgStock::make()->action($orgStock, ['barcode' => $barcode]);
+        });
+    }
+
+    public function authorize(ActionRequest $request): bool
+    {
+        return $request->user()->authTo(WarehousePermissionsEnum::getStockEditPermissionNames($this->organisation));
+    }
+
+    public function rules(): array
+    {
+        return [
+            'barcode' => ['required', 'string', 'max:54', 'regex:/^[\x20-\x7E]+$/'],
+        ];
+    }
+
+    public function asController(Organisation $organisation, Warehouse $warehouse, OrgStock $orgStock, ActionRequest $request): array
+    {
+        $this->initialisationFromWarehouse($warehouse, $request);
+
+        $orgStock = $this->handle($orgStock, $this->validatedData['barcode']);
+
+        return [
+            'barcode'    => $orgStock->barcode,
+            'found'      => true,
+            'matched_on' => 'sko',
+            'org_stock'  => ScanSkoBarcode::card($warehouse, $orgStock),
+        ];
+    }
+}

--- a/app/Actions/Inventory/OrgStock/Json/GetOrgStocks.php
+++ b/app/Actions/Inventory/OrgStock/Json/GetOrgStocks.php
@@ -55,6 +55,7 @@ class GetOrgStocks extends OrgAction
                 'org_stocks.name',
                 'org_stocks.state',
                 'org_stocks.sku_value',
+                'org_stocks.quantity_in_locations',
                 'org_stocks.discontinued_in_organisation_at',
                 'org_stock_families.slug as family_slug',
                 'org_stock_families.code as family_code',

--- a/app/Actions/Inventory/OrgStock/Json/ScanSkoBarcode.php
+++ b/app/Actions/Inventory/OrgStock/Json/ScanSkoBarcode.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Wed, 02 Sep 2026, Kuala Lumpur, Malaysia
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\Inventory\OrgStock\Json;
+
+use App\Actions\OrgAction;
+use App\Actions\Traits\Authorisations\Inventory\WithInventoryAuthorisation;
+use App\Models\Inventory\LocationOrgStock;
+use App\Models\Inventory\OrgStock;
+use App\Models\Inventory\Warehouse;
+use App\Models\SysAdmin\Organisation;
+use Lorisleiva\Actions\ActionRequest;
+
+/**
+ * A scanner in the warehouse may read the CODE 128 on the outer packing or the EAN13 on the unit
+ * inside it, so a scan is matched against both numbers, outer first.
+ */
+class ScanSkoBarcode extends OrgAction
+{
+    use WithInventoryAuthorisation;
+
+    public function handle(Organisation $organisation, string $barcode): ?OrgStock
+    {
+        $barcode = trim($barcode);
+        if ($barcode === '') {
+            return null;
+        }
+
+        $query = OrgStock::where('organisation_id', $organisation->id);
+
+        return (clone $query)->where('barcode', $barcode)->first()
+            ?? (clone $query)->where('unit_barcode', $barcode)->first();
+    }
+
+    /**
+     * @return array{id: int, slug: string, code: string, name: string, state: array, barcode: ?string, unit_barcode: ?string, packed_in: mixed, quantity_in_locations: mixed, image: mixed, locations: array, route: array}
+     */
+    public static function card(Warehouse $warehouse, OrgStock $orgStock): array
+    {
+        $locations = LocationOrgStock::where('org_stock_id', $orgStock->id)
+            ->where('warehouse_id', $warehouse->id)
+            ->with('location')
+            ->get()
+            ->map(fn (LocationOrgStock $locationOrgStock) => [
+                'code'     => $locationOrgStock->location->code,
+                'quantity' => trimDecimalZeros($locationOrgStock->quantity ?? 0),
+            ])
+            ->sortBy('code')
+            ->values()
+            ->all();
+
+        return [
+            'id'                    => $orgStock->id,
+            'slug'                  => $orgStock->slug,
+            'code'                  => $orgStock->code,
+            'name'                  => $orgStock->name,
+            'state'                 => $orgStock->state->stateIcon()[$orgStock->state->value],
+            'barcode'               => $orgStock->barcode,
+            'unit_barcode'          => $orgStock->unit_barcode,
+            'packed_in'             => trimDecimalZeros($orgStock->packed_in),
+            'quantity_in_locations' => trimDecimalZeros($orgStock->quantity_in_locations),
+            'image'                 => $orgStock->tradeUnits->first()?->imageSources(0, 384),
+            'locations'             => $locations,
+            'route'                 => [
+                'name'       => 'grp.org.warehouses.show.inventory.org_stocks.current_org_stocks.show',
+                'parameters' => [
+                    'organisation' => $warehouse->organisation->slug,
+                    'warehouse'    => $warehouse->slug,
+                    'orgStock'     => $orgStock->slug,
+                ],
+            ],
+        ];
+    }
+
+    public function rules(): array
+    {
+        return [
+            'barcode' => ['required', 'string', 'max:64'],
+        ];
+    }
+
+    public function asController(Warehouse $warehouse, ActionRequest $request): array
+    {
+        $this->initialisationFromWarehouse($warehouse, $request);
+
+        $barcode  = $this->validatedData['barcode'];
+        $orgStock = $this->handle($warehouse->organisation, $barcode);
+
+        return [
+            'barcode'    => trim($barcode),
+            'found'      => (bool) $orgStock,
+            'matched_on' => $orgStock ? ($orgStock->barcode === trim($barcode) ? 'sko' : 'unit') : null,
+            'org_stock'  => $orgStock ? static::card($warehouse, $orgStock) : null,
+        ];
+    }
+}

--- a/app/Actions/Inventory/OrgStock/UI/ShowSkoBarcodeScanner.php
+++ b/app/Actions/Inventory/OrgStock/UI/ShowSkoBarcodeScanner.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * Author: Raul Perusquia <raul@inikoo.com>
+ * Created: Wed, 02 Sep 2026, Kuala Lumpur, Malaysia
+ * Copyright (c) 2026, Raul A Perusquia Flores
+ */
+
+namespace App\Actions\Inventory\OrgStock\UI;
+
+use App\Actions\Inventory\UI\ShowInventoryDashboard;
+use App\Actions\OrgAction;
+use App\Actions\Traits\Authorisations\Inventory\WithInventoryAuthorisation;
+use App\Models\Inventory\Warehouse;
+use App\Models\SysAdmin\Organisation;
+use Inertia\Inertia;
+use Inertia\Response;
+use Lorisleiva\Actions\ActionRequest;
+
+class ShowSkoBarcodeScanner extends OrgAction
+{
+    use WithInventoryAuthorisation;
+
+    public function asController(Organisation $organisation, Warehouse $warehouse, ActionRequest $request): Response
+    {
+        $this->initialisationFromWarehouse($warehouse, $request);
+
+        $routeParameters = $request->route()->originalParameters();
+
+        return Inertia::render('Org/Inventory/SkoBarcodeScanner', [
+            'breadcrumbs' => $this->getBreadcrumbs($routeParameters),
+            'title'       => __('SKO barcodes'),
+            'pageHead'    => [
+                'title' => __('SKO barcodes'),
+                'model' => __('Inventory'),
+                'icon'  => ['icon' => 'fal fa-barcode-read'],
+            ],
+            'can_edit'     => $this->canEdit,
+            'scan_route'   => [
+                'name'       => 'grp.json.warehouse.scan_sko_barcode',
+                'parameters' => ['warehouse' => $warehouse->slug],
+            ],
+            'search_route' => [
+                'name'       => 'grp.json.org_stocks.index',
+                'parameters' => ['organisation' => $organisation->id],
+            ],
+            'assign_route' => [
+                'name'       => 'grp.org.warehouses.show.inventory.org_stocks.assign_sko_barcode',
+                'parameters' => $routeParameters,
+            ],
+        ]);
+    }
+
+    public function getBreadcrumbs(array $routeParameters): array
+    {
+        return array_merge(
+            ShowInventoryDashboard::make()->getBreadcrumbs($routeParameters),
+            [
+                [
+                    'type'   => 'simple',
+                    'simple' => [
+                        'route' => [
+                            'name'       => 'grp.org.warehouses.show.inventory.org_stocks.barcode_scanner',
+                            'parameters' => $routeParameters,
+                        ],
+                        'label' => __('SKO barcodes'),
+                    ],
+                ],
+            ]
+        );
+    }
+}

--- a/app/Actions/Inventory/UI/ShowInventoryDashboard.php
+++ b/app/Actions/Inventory/UI/ShowInventoryDashboard.php
@@ -55,6 +55,18 @@ class ShowInventoryDashboard extends OrgAction
                         'icon'  => ['fal', 'fa-chart-network'],
                         'title' => __('Inventory')
                     ],
+                    'actions'   => [
+                        [
+                            'type'  => 'button',
+                            'style' => 'tertiary',
+                            'icon'  => 'fal fa-barcode-read',
+                            'label' => __('Scan SKO barcodes'),
+                            'route' => [
+                                'name'       => 'grp.org.warehouses.show.inventory.org_stocks.barcode_scanner',
+                                'parameters' => $routeParameters
+                            ],
+                        ],
+                    ],
                 ],
                 'flatTreeMaps' => [
                     [

--- a/resources/js/Pages/Grp/Org/Inventory/SkoBarcodeScanner.vue
+++ b/resources/js/Pages/Grp/Org/Inventory/SkoBarcodeScanner.vue
@@ -1,0 +1,387 @@
+<!--
+  -  Author: Raul Perusquia <raul@inikoo.com>
+  -  Created: Wed, 02 Sep 2026, Kuala Lumpur, Malaysia
+  -  Copyright (c) 2026, Raul A Perusquia Flores
+  -->
+
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from "vue"
+import { Head, Link } from "@inertiajs/vue3"
+import axios from "axios"
+import { debounce } from "lodash-es"
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome"
+import { library } from "@fortawesome/fontawesome-svg-core"
+import { faBarcodeRead, faCheck, faCheckCircle, faExchange, faSearch, faTimesCircle, faTimes, faInventory, faBox, faArrowLeft } from "@fal"
+import { trans } from "laravel-vue-i18n"
+import { capitalize } from "@/Composables/capitalize"
+import { playNotificationSound } from "@/Composables/useNotificationSound"
+import { useBarcodeScanner } from "@/Composables/useBarcodeScanner"
+import { notify } from "@kyvg/vue3-notification"
+import PageHeading from "@/Components/Headings/PageHeading.vue"
+import Image from "@/Common/Components/Image.vue"
+import LoadingIcon from "@/Components/Utils/LoadingIcon.vue"
+import { PageHeadingTypes } from "@/types/PageHeading"
+import { routeType } from "@/types/route"
+
+library.add(faBarcodeRead, faCheck, faCheckCircle, faExchange, faSearch, faTimesCircle, faTimes, faInventory, faBox, faArrowLeft)
+
+const props = defineProps<{
+    title: string
+    pageHead: PageHeadingTypes
+    can_edit: boolean
+    scan_route: routeType
+    search_route: routeType
+    assign_route: routeType
+}>()
+
+type OrgStockCard = {
+    id: number
+    slug: string
+    code: string
+    name: string
+    state: { icon: string; class: string; tooltip: string }
+    barcode: string | null
+    unit_barcode: string | null
+    packed_in: string | number | null
+    quantity_in_locations: string | number
+    image: any
+    locations: { code: string; quantity: string | number }[]
+    route: routeType
+}
+
+type ScanResult = { barcode: string; found: boolean; matched_on: "sko" | "unit" | null; org_stock: OrgStockCard | null }
+type SearchRow = { id: number; slug: string; code: string; name: string; quantity_in_locations: string | number }
+
+const isScanning = ref(false)
+const result = ref<ScanResult | null>(null)
+const justAssigned = ref(false)
+const okCount = ref(0)
+
+const mode = ref<"scan" | "search">("scan")
+const searchQuery = ref("")
+const searchRows = ref<SearchRow[]>([])
+const isSearching = ref(false)
+const searchInput = ref<HTMLInputElement | null>(null)
+const candidate = ref<SearchRow | null>(null)
+const isAssigning = ref(false)
+
+const scannedBarcode = computed(() => result.value?.barcode ?? "")
+
+const scan = async (code: string) => {
+    const barcode = code.trim()
+    if (!barcode || isScanning.value) {
+        return
+    }
+
+    if (candidate.value) {
+        result.value = { barcode, found: false, matched_on: null, org_stock: null }
+        playNotificationSound({ frequency: 880, duration: 60 })
+        return
+    }
+
+    isScanning.value = true
+    justAssigned.value = false
+    mode.value = "scan"
+
+    try {
+        const { data } = await axios.get<ScanResult>(route(props.scan_route.name, props.scan_route.parameters), { params: { barcode } })
+        result.value = data
+        if (data.found) {
+            playNotificationSound({ frequency: 1180, duration: 90 })
+        } else {
+            playNotificationSound({ frequency: 200, duration: 280, type: "square" })
+        }
+    } catch (error: any) {
+        notify({ title: trans("Scan failed"), text: error?.response?.data?.message ?? trans("Please try again."), type: "error" })
+    } finally {
+        isScanning.value = false
+    }
+}
+
+const { buffer, inputElement, registerKeystroke, clearBuffer, flushBuffer } = useBarcodeScanner(scan)
+
+const confirmOk = () => {
+    okCount.value++
+    playNotificationSound({ frequency: 880, duration: 60 })
+    result.value = null
+    justAssigned.value = false
+}
+
+const openSearch = async () => {
+    mode.value = "search"
+    searchQuery.value = ""
+    searchRows.value = []
+    candidate.value = null
+    await nextTick()
+    searchInput.value?.focus()
+}
+
+const closeSearch = () => {
+    mode.value = "scan"
+    candidate.value = null
+}
+
+const runSearch = debounce(async (query: string) => {
+    if (query.trim().length < 2) {
+        searchRows.value = []
+        return
+    }
+
+    isSearching.value = true
+    try {
+        const { data } = await axios.get(route(props.search_route.name, props.search_route.parameters), {
+            params: { "filter[global]": query.trim(), perPage: 30 },
+        })
+        searchRows.value = data.data
+    } finally {
+        isSearching.value = false
+    }
+}, 250)
+
+watch(searchQuery, query => runSearch(query))
+
+const assign = async () => {
+    if (!candidate.value || !scannedBarcode.value || isAssigning.value) {
+        return
+    }
+
+    isAssigning.value = true
+    try {
+        const { data } = await axios.patch<ScanResult>(
+            route(props.assign_route.name, { ...props.assign_route.parameters, orgStock: candidate.value.slug }),
+            { barcode: scannedBarcode.value }
+        )
+        result.value = data
+        justAssigned.value = true
+        mode.value = "scan"
+        candidate.value = null
+        playNotificationSound({ frequency: 1180, duration: 90 })
+    } catch (error: any) {
+        const errors = error?.response?.data?.errors
+        notify({
+            title: trans("Could not assign barcode"),
+            text: errors ? Object.values(errors).flat().join(" ") : (error?.response?.data?.message ?? trans("Please try again.")),
+            type: "error",
+        })
+    } finally {
+        isAssigning.value = false
+    }
+}
+</script>
+
+<template>
+    <Head :title="capitalize(title)" />
+    <PageHeading :data="pageHead" />
+
+    <div class="mx-auto w-full max-w-lg px-3 py-3 space-y-3">
+        <div class="relative">
+            <input
+                ref="inputElement"
+                v-model="buffer"
+                type="text"
+                inputmode="none"
+                autocomplete="off"
+                spellcheck="false"
+                :placeholder="trans('Scan a SKO barcode')"
+                style="padding-left:3rem"
+                class="w-full rounded-xl border-2 border-gray-300 bg-white py-4 pr-12 font-mono text-lg tracking-wide focus:border-indigo-500 focus:ring-indigo-500"
+                @keydown.enter.prevent="flushBuffer"
+                @keydown.esc.prevent="clearBuffer"
+                @input="registerKeystroke"
+            />
+            <FontAwesomeIcon icon="fal fa-barcode-read" class="absolute left-4 top-1/2 -translate-y-1/2 text-xl text-gray-400" fixed-width aria-hidden="true" />
+            <span v-if="isScanning" class="absolute right-4 top-1/2 -translate-y-1/2 text-indigo-500">
+                <LoadingIcon fixed-width aria-hidden="true" />
+            </span>
+        </div>
+
+        <div class="flex items-center justify-between text-sm text-gray-500">
+            <span>{{ trans('Checked') }}: <span class="font-medium tabular-nums text-gray-700">{{ okCount }}</span></span>
+            <button
+                v-if="mode === 'scan' && can_edit && !result"
+                type="button"
+                class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-indigo-600 active:bg-indigo-50"
+                @click="openSearch"
+            >
+                <FontAwesomeIcon icon="fal fa-search" fixed-width aria-hidden="true" />
+                {{ trans('Find a SKO') }}
+            </button>
+        </div>
+
+        <template v-if="mode === 'scan'">
+            <div v-if="result && !result.found" class="rounded-xl border-2 border-red-300 bg-red-50 p-4">
+                <div class="flex items-center gap-3 text-red-800">
+                    <FontAwesomeIcon icon="fal fa-times-circle" class="text-3xl text-red-500" fixed-width aria-hidden="true" />
+                    <div>
+                        <div class="font-semibold">{{ trans('Barcode not found') }}</div>
+                        <div class="font-mono text-sm">{{ result.barcode }}</div>
+                    </div>
+                </div>
+                <div class="mt-4 grid gap-2">
+                    <button
+                        v-if="can_edit"
+                        type="button"
+                        class="flex min-h-14 w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 text-base font-semibold text-white active:bg-indigo-700"
+                        @click="openSearch"
+                    >
+                        <FontAwesomeIcon icon="fal fa-search" fixed-width aria-hidden="true" />
+                        {{ trans('Assign to a SKO') }}
+                    </button>
+                    <button
+                        type="button"
+                        class="flex min-h-12 w-full items-center justify-center gap-2 rounded-xl border-2 border-gray-300 bg-white text-base font-medium text-gray-700 active:bg-gray-100"
+                        @click="result = null"
+                    >
+                        {{ trans('Skip') }}
+                    </button>
+                </div>
+            </div>
+
+            <div v-else-if="result?.org_stock" class="rounded-xl border-2 bg-white p-4" :class="justAssigned ? 'border-green-400' : 'border-gray-200'">
+                <div v-if="justAssigned" class="mb-3 flex items-center gap-2 rounded-lg bg-green-50 px-3 py-2 text-sm font-medium text-green-800">
+                    <FontAwesomeIcon icon="fal fa-check-circle" class="text-green-600" fixed-width aria-hidden="true" />
+                    {{ trans('Barcode assigned') }}
+                </div>
+
+                <div class="flex gap-4">
+                    <div class="h-28 w-28 shrink-0 overflow-hidden rounded-lg bg-gray-100">
+                        <Image v-if="result.org_stock.image" :src="result.org_stock.image" class="h-full w-full object-contain" />
+                        <div v-else class="flex h-full w-full items-center justify-center text-gray-300">
+                            <FontAwesomeIcon icon="fal fa-box" class="text-3xl" fixed-width aria-hidden="true" />
+                        </div>
+                    </div>
+                    <div class="min-w-0 flex-1">
+                        <Link :href="route(result.org_stock.route.name, result.org_stock.route.parameters)" class="font-mono text-lg font-semibold text-gray-900">
+                            {{ result.org_stock.code }}
+                        </Link>
+                        <div class="text-sm text-gray-700">{{ result.org_stock.name }}</div>
+                        <div class="mt-1 flex items-center gap-1.5 text-xs text-gray-500">
+                            <FontAwesomeIcon :icon="result.org_stock.state.icon" :class="result.org_stock.state.class" fixed-width aria-hidden="true" />
+                            {{ result.org_stock.state.tooltip }}
+                            <span v-if="result.org_stock.packed_in">· {{ trans('Pack of :n', { n: result.org_stock.packed_in }) }}</span>
+                        </div>
+                        <div class="mt-1 font-mono text-xs text-gray-500">
+                            {{ result.matched_on === 'unit' ? trans('Unit EAN') : trans('SKO') }} {{ result.barcode }}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="mt-4 rounded-lg bg-gray-50 p-3">
+                    <div class="flex items-center justify-between text-sm">
+                        <span class="flex items-center gap-1.5 text-gray-500">
+                            <FontAwesomeIcon icon="fal fa-inventory" fixed-width aria-hidden="true" />
+                            {{ trans('Stock') }}
+                        </span>
+                        <span class="font-semibold tabular-nums text-gray-900">{{ result.org_stock.quantity_in_locations }}</span>
+                    </div>
+                    <div v-if="result.org_stock.locations.length" class="mt-2 divide-y divide-gray-200">
+                        <div v-for="location in result.org_stock.locations" :key="location.code" class="flex items-center justify-between py-1.5 text-sm">
+                            <span class="font-mono font-medium text-gray-700">{{ location.code }}</span>
+                            <span class="tabular-nums text-gray-700">{{ location.quantity }}</span>
+                        </div>
+                    </div>
+                    <div v-else class="mt-2 text-sm text-gray-400">{{ trans('Not in any location') }}</div>
+                </div>
+
+                <div class="mt-4 grid gap-2">
+                    <button
+                        type="button"
+                        class="flex min-h-14 w-full items-center justify-center gap-2 rounded-xl bg-green-600 text-base font-semibold text-white active:bg-green-700"
+                        @click="confirmOk"
+                    >
+                        <FontAwesomeIcon icon="fal fa-check" fixed-width aria-hidden="true" />
+                        {{ trans('All OK') }}
+                    </button>
+                    <button
+                        v-if="can_edit && !justAssigned"
+                        type="button"
+                        class="flex min-h-12 w-full items-center justify-center gap-2 rounded-xl border-2 border-amber-400 bg-white text-base font-medium text-amber-800 active:bg-amber-50"
+                        @click="openSearch"
+                    >
+                        <FontAwesomeIcon icon="fal fa-exchange" fixed-width aria-hidden="true" />
+                        {{ trans('Wrong SKO, move barcode') }}
+                    </button>
+                </div>
+            </div>
+
+            <div v-else class="rounded-xl border-2 border-dashed border-gray-300 p-8 text-center text-gray-400">
+                <FontAwesomeIcon icon="fal fa-barcode-read" class="text-4xl" fixed-width aria-hidden="true" />
+                <div class="mt-2 text-sm">{{ trans('Scan a SKO to check it') }}</div>
+            </div>
+        </template>
+
+        <template v-else>
+            <div class="rounded-xl border-2 border-gray-200 bg-white p-3">
+                <div class="mb-2 flex items-center gap-2">
+                    <button type="button" class="flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 active:bg-gray-100" @click="closeSearch">
+                        <FontAwesomeIcon icon="fal fa-arrow-left" fixed-width aria-hidden="true" />
+                    </button>
+                    <div class="min-w-0 flex-1 text-sm text-gray-600">
+                        <template v-if="scannedBarcode">
+                            {{ trans('Assign') }} <span class="font-mono font-semibold text-gray-900">{{ scannedBarcode }}</span> {{ trans('to') }}:
+                        </template>
+                        <template v-else>{{ trans('Find a SKO, then scan its barcode') }}</template>
+                    </div>
+                </div>
+
+                <div class="relative">
+                    <input
+                        ref="searchInput"
+                        v-model="searchQuery"
+                        type="search"
+                        autocomplete="off"
+                        :placeholder="trans('SKO code or name')"
+                        class="w-full rounded-xl border-2 border-gray-300 py-3 pl-11 pr-4 text-base focus:border-indigo-500 focus:ring-indigo-500"
+                    />
+                    <FontAwesomeIcon icon="fal fa-search" class="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400" fixed-width aria-hidden="true" />
+                    <span v-if="isSearching" class="absolute right-4 top-1/2 -translate-y-1/2 text-indigo-500"><LoadingIcon /></span>
+                </div>
+
+                <div v-if="candidate" class="mt-3 rounded-xl border-2 border-indigo-300 bg-indigo-50 p-3">
+                    <div class="font-mono text-lg font-semibold text-gray-900">{{ candidate.code }}</div>
+                    <div class="text-sm text-gray-700">{{ candidate.name }}</div>
+                    <div class="mt-3 grid grid-cols-2 gap-2">
+                        <button
+                            type="button"
+                            class="flex min-h-14 items-center justify-center gap-2 rounded-xl border-2 border-gray-300 bg-white text-base font-medium text-gray-700 active:bg-gray-100"
+                            @click="candidate = null"
+                        >
+                            <FontAwesomeIcon icon="fal fa-times" fixed-width aria-hidden="true" />
+                            {{ trans('Cancel') }}
+                        </button>
+                        <button
+                            type="button"
+                            :disabled="isAssigning || !scannedBarcode"
+                            class="flex min-h-14 items-center justify-center gap-2 rounded-xl bg-indigo-600 text-base font-semibold text-white active:bg-indigo-700 disabled:opacity-50"
+                            @click="assign"
+                        >
+                            <LoadingIcon v-if="isAssigning" />
+                            <FontAwesomeIcon v-else icon="fal fa-check" fixed-width aria-hidden="true" />
+                            {{ trans('Assign') }}
+                        </button>
+                    </div>
+                    <div v-if="!scannedBarcode" class="mt-2 text-center text-xs text-gray-500">{{ trans('Scan the barcode now to assign it') }}</div>
+                </div>
+
+                <ul v-else class="mt-2 divide-y divide-gray-100">
+                    <li v-for="row in searchRows" :key="row.id">
+                        <button
+                            type="button"
+                            class="flex min-h-14 w-full items-center justify-between gap-3 px-2 text-left active:bg-indigo-50"
+                            @click="candidate = row"
+                        >
+                            <div class="min-w-0">
+                                <div class="font-mono font-semibold text-gray-900">{{ row.code }}</div>
+                                <div class="truncate text-sm text-gray-600">{{ row.name }}</div>
+                            </div>
+                            <div class="shrink-0 text-sm tabular-nums text-gray-500">{{ row.quantity_in_locations }}</div>
+                        </button>
+                    </li>
+                    <li v-if="!searchRows.length && searchQuery.trim().length >= 2 && !isSearching" class="py-6 text-center text-sm text-gray-400">
+                        {{ trans('No SKOs match') }}
+                    </li>
+                </ul>
+            </div>
+        </template>
+    </div>
+</template>

--- a/routes/grp/web/json.php
+++ b/routes/grp/web/json.php
@@ -113,6 +113,7 @@ use App\Actions\Production\ArtefactFamily\UI\IndexArtefactFamilies;
 use App\Actions\Helpers\TimeZone\Json\IndexTimeZones;
 use App\Actions\Inventory\OrgStock\Json\FetchOrgStockStocksManagement;
 use App\Actions\Inventory\OrgStock\Json\GetOrgStocks;
+use App\Actions\Inventory\OrgStock\Json\ScanSkoBarcode;
 use App\Actions\Inventory\OrgStock\Json\GetOrgStocksInProduct;
 use App\Actions\Masters\MasterAsset\CheckMasterAssetTradeUnitOrgStockExistence;
 use App\Actions\Masters\MasterAsset\Json\GetPickFractional;
@@ -238,6 +239,7 @@ Route::get('order/{order:id}/products-for-modify', GetOrderProductsForModificati
 Route::get('organisation/{organisation}/shippers', GetShippers::class)->name('shippers.index');
 Route::get('organisation/{organisation:id}/org-stocks', GetOrgStocks::class)->name('org_stocks.index');
 Route::get('organisation/{organisation:id}/org-stock/{orgStock:id}/batch-codes', GetBatchCodes::class)->name('org_stock.batch_codes.index');
+Route::get('warehouse/{warehouse}/scan-sko-barcode', ScanSkoBarcode::class)->name('warehouse.scan_sko_barcode');
 Route::get('warehouse/{warehouse}/org-stock/{orgStock:id}/stocks-management', FetchOrgStockStocksManagement::class)->name('warehouse.org_stock.stocks_management')->withoutScopedBindings();
 
 Route::get('trade-units/{tradeUnit}/tags', [IndexTags::class, 'inTradeUnit'])->name('trade_units.tags.index');

--- a/routes/grp/web/org/warehouses/inventory.php
+++ b/routes/grp/web/org/warehouses/inventory.php
@@ -39,6 +39,8 @@ use App\Actions\Inventory\OrgStock\UI\ShowOrgStockProcurement;
 use App\Actions\Inventory\OrgStock\UI\ShowOrgStockProducts;
 use App\Actions\Inventory\OrgStock\UI\ShowOrgStockStockHistory;
 use App\Actions\Inventory\OrgStock\UI\PdfOrgStockLabel;
+use App\Actions\Inventory\OrgStock\UI\ShowSkoBarcodeScanner;
+use App\Actions\Inventory\OrgStock\AssignSkoBarcodeToOrgStock;
 use App\Actions\Inventory\OrgStock\UpdateOrgStock;
 use App\Actions\Inventory\OrgStock\UpdateOrgStockUnitBarcode;
 use App\Actions\Inventory\OrgStockFamily\UI\IndexInvoicesInOrgStockFamily;
@@ -63,7 +65,9 @@ Route::prefix('stock-histories')->as('org_stock_histories.')->group(function () 
 
 
 Route::prefix('stocks')->as('org_stocks.')->group(function () {
+    Route::get('barcode-scanner', ShowSkoBarcodeScanner::class)->name('barcode_scanner');
     Route::patch('{orgStock}/update', UpdateOrgStock::class)->name('update');
+    Route::patch('{orgStock}/assign-sko-barcode', AssignSkoBarcodeToOrgStock::class)->name('assign_sko_barcode');
     Route::patch('{orgStock}/update-unit-barcode', UpdateOrgStockUnitBarcode::class)->name('update_unit_barcode');
     Route::get('{orgStock}/label', PdfOrgStockLabel::class)->name('label');
 

--- a/tests/Feature/InventoryTest.php
+++ b/tests/Feature/InventoryTest.php
@@ -29,6 +29,8 @@ use App\Actions\Inventory\LocationOrgStock\MoveOrgStockToOtherLocation;
 use App\Actions\Inventory\LocationOrgStock\StoreLocationOrgStock;
 use App\Actions\Inventory\LocationOrgStock\UpdateLocationOrgStock;
 use App\Actions\Inventory\OrgStock\AddLostAndFoundOrgStock;
+use App\Actions\Inventory\OrgStock\AssignSkoBarcodeToOrgStock;
+use App\Actions\Inventory\OrgStock\Json\ScanSkoBarcode;
 use App\Actions\Inventory\OrgStock\AssociateOrgStockToOrgStockFamily;
 use App\Actions\Inventory\OrgStock\DeleteOrgStock;
 use App\Actions\Inventory\OrgStock\FillOrgStockWithTradeUnitsBarcodes;
@@ -2943,3 +2945,37 @@ test('stock history sweeps refuse to rewrite only the live years when the archiv
 
     expect($sweep->connection())->toBeNull();
 });
+
+test('sko barcode scanner finds an org stock by outer or unit barcode and moves a barcode between org stocks', function ($warehouse) {
+    $makeOrgStock = fn (string $code) => StoreOrgStock::make()->action(
+        $this->organisation,
+        StoreStock::make()->action($this->group, array_merge(Stock::factory()->definition(), ['code' => $code, 'state' => StockStateEnum::ACTIVE]))
+    );
+    $first  = $makeOrgStock('SCANA');
+    $second = $makeOrgStock('SCANB');
+    UpdateOrgStock::make()->action($first, ['barcode' => 'SKO-SCAN-1', 'unit_barcode' => '5050000000999']);
+
+    expect(ScanSkoBarcode::make()->handle($this->organisation, ' SKO-SCAN-1 ')?->id)->toBe($first->id)
+        ->and(ScanSkoBarcode::make()->handle($this->organisation, '5050000000999')?->id)->toBe($first->id)
+        ->and(ScanSkoBarcode::make()->handle($this->organisation, 'NOPE'))->toBeNull();
+
+    $scanUrl = fn (string $barcode) => route('grp.json.warehouse.scan_sko_barcode', ['warehouse' => $warehouse->slug, 'barcode' => $barcode]);
+    get($scanUrl('SKO-SCAN-1'))->assertOk()->assertJsonPath('found', true)->assertJsonPath('matched_on', 'sko')->assertJsonPath('org_stock.code', $first->code);
+    get($scanUrl('5050000000999'))->assertOk()->assertJsonPath('matched_on', 'unit');
+    get($scanUrl('NOPE'))->assertOk()->assertJsonPath('found', false)->assertJsonPath('org_stock', null);
+
+    $second = AssignSkoBarcodeToOrgStock::make()->handle($second, ' SKO-SCAN-1 ');
+    expect($second->barcode)->toBe('SKO-SCAN-1')
+        ->and($second->stock->refresh()->barcode)->toBe('SKO-SCAN-1')
+        ->and($first->refresh()->barcode)->toBeNull()
+        ->and($first->stock->refresh()->barcode)->toBeNull();
+
+    get(route('grp.org.warehouses.show.inventory.org_stocks.barcode_scanner', [$this->organisation->slug, $warehouse->slug]))
+        ->assertInertia(
+            fn (AssertableInertia $page) => $page
+                ->component('Org/Inventory/SkoBarcodeScanner')
+                ->where('scan_route.name', 'grp.json.warehouse.scan_sko_barcode')
+                ->where('assign_route.name', 'grp.org.warehouses.show.inventory.org_stocks.assign_sko_barcode')
+                ->etc()
+        );
+})->depends('create warehouse');


### PR DESCRIPTION
## What

A mobile-first page where warehouse staff walk the aisles with a barcode scanner and check that every SKO label points at the right SKO, fixing it on the spot when it does not.

Entry point: **Inventory dashboard → "Scan SKO barcodes"** button (top right), URL `/org/{org}/warehouses/{warehouse}/inventory/stocks/barcode-scanner`.

## How it behaves

| Scan result | What the operator sees | Buttons |
|---|---|---|
| Barcode known | SKO card: image, code, name, state, pack size, which barcode matched (outer SKO CODE 128 or unit EAN13), total stock, stock per location | **All OK** (counts it, ready for next scan) · **Wrong SKO, move barcode** |
| Barcode unknown | Red "Barcode not found" with the scanned number | **Assign to a SKO** · **Skip** |
| Idle | Scan prompt | **Find a SKO** (pick the SKO first, scan its label afterwards) |

"Move" and "Assign" open a search box: type part of the code or name, tap a row, confirm with a big **Assign** button. The card comes back green with "Barcode assigned".

The scan input captures scanner keystrokes anywhere on the page (same composable as picking), with or without an Enter suffix. A beep confirms found, a low buzz means not found.

## Backend

- `ScanSkoBarcode` (JSON, `grp.json.warehouse.scan_sko_barcode`): looks the number up in the organisation's org stocks by `barcode` (outer) first, then `unit_barcode`. Returns `found`, `matched_on` and the card.
- `AssignSkoBarcodeToOrgStock` (PATCH `grp.org.warehouses.show.inventory.org_stocks.assign_sko_barcode`): the label in the scanner's hand is the truth. Any org stock of a *different* stock currently holding that barcode gives it up, then the target takes it, replacing whatever SKO barcode it had. Both writes go through `UpdateOrgStock`, so the parent stock and the sibling org stocks in other organisations follow, with history. Wrapped in one transaction. Requires stock edit permission (`inventory.{org}.edit`, `stocks.{wh}.edit` or `supervisor-stocks.{wh}`); view-only users get the check flow without the move/assign buttons.
- `ShowSkoBarcodeScanner`: Inertia page, breadcrumbs under Inventory.
- Search reuses the existing `grp.json.org_stocks.index` endpoint, which now also selects `quantity_in_locations` so rows show stock.
- Assigning a **unit** EAN this way writes it as the outer SKO barcode. Unit EANs belong to the trade unit and keep their own supervisor-gated editor on the SKO page.

## Tests

`tests/Feature/InventoryTest.php` → "sko barcode scanner finds an org stock by outer or unit barcode and moves a barcode between org stocks": lookup by both numbers, JSON endpoint for found / unit match / not found, move between two org stocks with the stock cascade checked both ways, page render with routes.

```bash
TEST_TOKEN=sko1 php -d xdebug.mode=off vendor/bin/pest --compact tests/Feature/InventoryTest.php --filter="create warehouse|sko barcode scanner"
```

## Manual QA

Use a phone or tablet (or a desktop window narrowed to ~430 px) and a USB/Bluetooth scanner in keyboard mode. Typing the number and pressing Enter works too.

Setup: pick two SKOs in the same warehouse, **A** with a SKO barcode and stock in at least one location, **B** without a barcode. Note A's barcode from its SKO page (Barcodes card).

1. **Link**: open the warehouse Inventory dashboard, tap "Scan SKO barcodes". Page opens with a scan box and "Checked: 0".
2. **Happy path**: scan A's barcode. Card shows A's image, code, name, state, pack size, "SKO <number>", total stock and each location with quantity. Tap **All OK**. Card clears, "Checked: 1".
3. **Unit EAN**: scan A's unit EAN13 (the small barcode on the product itself). Same card, label reads "Unit EAN <number>".
4. **Not found**: scan any random number. Red "Barcode not found" with the number, buttons "Assign to a SKO" and "Skip". Tap **Skip**, card clears.
5. **Assign unknown barcode**: scan the random number again, tap **Assign to a SKO**, type part of B's code, tap B, tap **Assign**. Green "Barcode assigned" card for B. Open B's SKO page: Barcodes card shows that number.
6. **Move a barcode**: scan A's barcode, tap **Wrong SKO, move barcode**, search B, tap it, **Assign**. B now carries A's barcode. Scan A's old barcode again: card shows **B**. Open A's SKO page: SKO barcode is empty. If A's stock exists in another organisation, its SKO barcode is empty there too.
7. **Find first, scan later**: from an empty page tap **Find a SKO**, search and tap a SKO, then scan a label. Assign button becomes active, tap it, green card for that SKO.
8. **Cancel paths**: in the search screen the back arrow returns to scanning; in the confirmation **Cancel** returns to the list.
9. **Permissions**: log in as a user with inventory *view* only. Scanning works, but "Wrong SKO, move barcode", "Assign to a SKO" and "Find a SKO" are hidden.
10. **Validation**: try assigning a barcode already carried by another SKO of the same stock in the same organisation, or a number with non-ASCII characters. A red notification explains the refusal, nothing changes.
11. **Cleanup**: put A's barcode back on A (step 6 in reverse).

Known: product images need the image proxy, so they are blank in local dev.
