### PR TITLE
Force Valid VAT

### DIFF
--- a/app/Actions/CRM/Customer/UI/EditCustomer.php
+++ b/app/Actions/CRM/Customer/UI/EditCustomer.php
@@ -122,10 +122,14 @@ class EditCustomer extends OrgAction
                     ],
                 ],
                 'tax_number'               => [
-                    'type'    => 'tax_number',
-                    'label'   => __('Tax number'),
-                    'value'   => $customer->taxNumber ? TaxNumberResource::make($customer->taxNumber)->getArray() : null,
-                    'country' => $customer->address->country_code,
+                    'type'                  => 'tax_number',
+                    'label'                 => __('Tax number'),
+                    'value'                 => $customer->taxNumber ? TaxNumberResource::make($customer->taxNumber)->getArray() : null,
+                    'mark_as_valid_button'  => [
+                        'show'      => true,
+                        'cus_id'    => $customer->id,
+                    ],
+                    'country'               => $customer->address->country_code,
                 ],
                 'is_re'                    => [
                     'type'   => 'toggle',

--- a/app/Actions/CRM/Customer/UpdateCustomer.php
+++ b/app/Actions/CRM/Customer/UpdateCustomer.php
@@ -20,6 +20,7 @@ use App\Actions\Helpers\Tag\AttachTagsToModel;
 use App\Actions\Helpers\TaxCategory\GetTaxCategory;
 use App\Actions\Helpers\TaxNumber\DeleteTaxNumber;
 use App\Actions\Helpers\TaxNumber\StoreTaxNumber;
+use App\Actions\Helpers\TaxNumber\Traits\WithValidateTaxNumberCustomAudit;
 use App\Actions\Helpers\TaxNumber\UpdateTaxNumber;
 use App\Actions\Ordering\Order\CalculateOrderDiscounts;
 use App\Actions\Ordering\Order\CalculateOrderTotalAmounts;
@@ -41,10 +42,13 @@ use App\Enums\CRM\Customer\CustomerStateEnum;
 use App\Enums\CRM\Customer\CustomerStatusEnum;
 use App\Enums\Dispatching\DeliveryNote\DeliveryNoteStateEnum;
 use App\Enums\Helpers\Audit\AuditEventEnum;
+use App\Enums\Helpers\TaxNumber\TaxNumberStatusEnum;
+use App\Enums\Helpers\TaxNumber\TaxNumberValidationTypeEnum;
 use App\Enums\Ordering\Order\OrderStateEnum;
 use App\Http\Resources\CRM\CustomersResource;
 use App\Models\CRM\Customer;
 use App\Models\Ordering\Order;
+use App\Models\SysAdmin\User;
 use App\Rules\IUnique;
 use App\Rules\Phone;
 use App\Rules\ValidAddress;
@@ -64,8 +68,10 @@ class UpdateCustomer extends OrgAction
     use WithProcessContactNameComponents;
     use WithCRMEditAuthorisation;
     use WithPrepareTaxNumberValidation;
+    use WithValidateTaxNumberCustomAudit;
 
     private Customer $customer;
+    private ?User $user = null;
 
     public function handle(Customer $customer, array $modelData): Customer
     {
@@ -141,37 +147,58 @@ class UpdateCustomer extends OrgAction
             }
         }
 
-        if (Arr::has($modelData, 'tax_number')) {
-            if ($this->strict) {
-                $taxNumberData = [];
-                data_set($taxNumberData, 'number', Arr::get($modelData, 'tax_number.number'));
-                data_set($taxNumberData, 'country_id', $customer->address->country_id);
-                Arr::forget($modelData, 'tax_number');
-            } else {
-                $taxNumberData = Arr::pull($modelData, 'tax_number');
+        if (Arr::hasAny($modelData, ['tax_number', 'mark_tax_number_valid'])) {
+            if (Arr::has($modelData, 'tax_number')) {
+                if ($this->strict) {
+                    $taxNumberData = [];
+                    data_set($taxNumberData, 'number', Arr::get($modelData, 'tax_number.number'));
+                    data_set($taxNumberData, 'country_id', $customer->address->country_id);
+                    Arr::forget($modelData, 'tax_number');
+                } else {
+                    $taxNumberData = Arr::pull($modelData, 'tax_number');
+                }
+
+                if (Arr::get($taxNumberData, 'number')) {
+                    if (!$customer->taxNumber) {
+                        if (!Arr::get($taxNumberData, 'data.name')) {
+                            Arr::forget($taxNumberData, 'data.name');
+                        }
+
+                        if (!Arr::get($taxNumberData, 'data.address')) {
+                            Arr::forget($taxNumberData, 'data.address');
+                        }
+
+                        StoreTaxNumber::run(
+                            owner: $customer,
+                            modelData: $taxNumberData,
+                            strict: $this->strict
+                        );
+                    } else {
+                        UpdateTaxNumber::run($customer->taxNumber, $taxNumberData, $this->strict);
+                    }
+                } elseif ($customer->taxNumber) {
+                    DeleteTaxNumber::run($customer->taxNumber);
+                }
             }
 
+            $markAsValid = Arr::pull($modelData, 'mark_tax_number_valid', false);
 
-            if (Arr::get($taxNumberData, 'number')) {
-                if (!$customer->taxNumber) {
-                    if (!Arr::get($taxNumberData, 'data.name')) {
-                        Arr::forget($taxNumberData, 'data.name');
-                    }
+            if ($markAsValid && $customer->taxNumber) {
+                $taxNumber = $customer->taxNumber;
+                $oldTaxNumber = $taxNumber->replicate();
 
-                    if (!Arr::get($taxNumberData, 'data.address')) {
-                        Arr::forget($taxNumberData, 'data.address');
-                    }
+                $updatedData = [
+                    'status'                    => TaxNumberStatusEnum::VALID,
+                    'valid'                     => true,
+                ];
 
-                    StoreTaxNumber::run(
-                        owner: $customer,
-                        modelData: $taxNumberData,
-                        strict: $this->strict
-                    );
-                } else {
-                    UpdateTaxNumber::run($customer->taxNumber, $taxNumberData, $this->strict);
+                if ($this->user) {
+                    data_set($updatedData, 'manual_validation_user_id', $this->user?->id);
                 }
-            } elseif ($customer->taxNumber) {
-                DeleteTaxNumber::run($customer->taxNumber);
+
+                $taxNumber->update($updatedData);
+
+                $this->deployTaxValidationCustomAudit($oldTaxNumber, $taxNumber, TaxNumberValidationTypeEnum::MANUAL);
             }
 
             // Recalculate customer orders VAT Charges | INI-875
@@ -375,6 +402,7 @@ class UpdateCustomer extends OrgAction
                 'nullable',
                 Rule::exists('employees', 'id')->where('organisation_id', $this->organisation->id),
             ],
+            'mark_tax_number_valid'                                 => ['sometimes', 'boolean', Rule::prohibitedIf(fn () => empty($this->customer?->taxNumber))],
         ];
 
         if ($this?->asAction) {
@@ -414,6 +442,7 @@ class UpdateCustomer extends OrgAction
 
     public function asController(Customer $customer, ActionRequest $request): Customer
     {
+        $this->user = $request->user();
         $this->customer = $customer;
         $this->initialisationFromShop($customer->shop, $request);
 

--- a/app/Actions/Helpers/TaxNumber/Traits/WithValidateTaxNumberCustomAudit.php
+++ b/app/Actions/Helpers/TaxNumber/Traits/WithValidateTaxNumberCustomAudit.php
@@ -27,14 +27,19 @@ trait WithValidateTaxNumberCustomAudit
             'tax_number'           => $oldTaxNumber->number == $newTaxNumber->number ? null : $oldTaxNumber->number, // To trick always show tax number on VAT Validation History (If old & new is the same, won't be displayed)
         ];
 
-        $customer->auditCustomNew = array_filter([
+        $updatedData = [
             'country_code'          => $newTaxNumber->country_code,
             'tax_number'            => $newTaxNumber->number,
             'status'                => ucfirst($newTaxNumber->status->value),
-            'third_party_status'    => $thirdPartyStatus,
             'validation_type'       => ucfirst($validationType->value),
             'validated_at'          => now()->format('d/m/Y H:i A T'),
-        ]);
+        ];
+
+        if ($validationType != TaxNumberValidationTypeEnum::MANUAL) {
+            data_set($updatedData, 'third_party_status', $thirdPartyStatus);
+        }
+
+        $customer->auditCustomNew = array_filter($updatedData);
 
         Event::dispatch(new AuditCustom($customer));
     }

--- a/app/Actions/Helpers/TaxNumber/ValidateEuropeanTaxNumber.php
+++ b/app/Actions/Helpers/TaxNumber/ValidateEuropeanTaxNumber.php
@@ -74,7 +74,6 @@ class ValidateEuropeanTaxNumber
                     'status'             => TaxNumberStatusEnum::INVALID,
                     'checked_at'         => now(),
                     'invalid_checked_at' => now()
-
                 ];
                 $taxNumber->update($validationData);
                 $taxNumber->refresh();

--- a/resources/js/Components/Forms/Fields/TaxNumber.vue
+++ b/resources/js/Components/Forms/Fields/TaxNumber.vue
@@ -4,7 +4,7 @@ import { set, get, debounce } from 'lodash-es'
 import { checkVAT, countries } from "jsvat-next"
 import { ref, computed, watch ,inject} from "vue"
 import { faExclamationCircle, faCheckCircle } from '@fas'
-import { faCopy } from '@fal'
+import { faCopy, faCheck } from '@fal'
 import { faSpinnerThird } from '@fad'
 import { library } from "@fortawesome/fontawesome-svg-core"
 import { trans } from "laravel-vue-i18n"
@@ -12,6 +12,11 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { useFormatTime } from '@/Composables/useFormatTime'
 import { Tooltip } from 'floating-vue'
 import Modal from "@/Components/Utils/Modal.vue"
+import Button from "@/Components/Elements/Buttons/Button.vue"
+import { router } from "@inertiajs/vue3"
+import ModalConfirmation from "@/Components/Utils/ModalConfirmation.vue"
+import { notify } from "@kyvg/vue3-notification"
+
 library.add(faExclamationCircle, faCheckCircle, faSpinnerThird, faCopy)
 defineOptions({ inheritAttrs: false })
 
@@ -207,8 +212,6 @@ const validateVAT = (vatInput: any) => {
     const validation = checkVAT(vatNumberWithCountryCode, countries);
     vatValidationResult.value = validation.isValid ? trans("Valid tax number") : trans("Invalid tax number");
 
-
-
     // Handle invalid VAT
     if (!validation.isValid) {
         const messageWarning = '🤔 ' + trans('Tax number looks invalid. Are you sure you want to save it?')
@@ -264,6 +267,39 @@ watch(
     },
     { deep: true }
 )
+
+const isLoadingMarkValid = ref(false);
+const markAsValid = () => {
+    console.log("KONTOL", props.fieldData.mark_as_valid_button.cus_id);
+    router.patch(route('grp.models.customer.update', {
+            customer: props.fieldData.mark_as_valid_button.cus_id
+        }), {
+            mark_tax_number_valid: true
+        }, 
+        {
+            onStart: () => (
+                isLoadingMarkValid.value = true
+            ),
+            onFinish: () => {
+                isLoadingMarkValid.value = false
+                reload?.()
+                notify({
+                    title: ctrans("Success"),
+                    text: ctrans("Marked Tax Number as Valid"),
+                    type: "success",
+                })
+            },
+            onError: (errors: any) => {
+                notify({
+                    title: ctrans("Error Occured"),
+                    text: errors?.message || ctrans("Unknown error occurred"),
+                    type: "error",
+                })
+            },
+        }
+    )
+}
+
 </script>
 
 <template>
@@ -323,6 +359,29 @@ watch(
                         </p>
                     </div>
                 </div>
+            </div>
+            <div v-if="validationStatus.status == 'invalid' && fieldData.mark_as_valid_button?.show" class="flex items-start pt-2">
+                <ModalConfirmation
+                    :title="ctrans('Are you sure you want to proceed?')"
+                    :description="ctrans(`Please make sure you've checked the VAT Details with upmost detail first before proceeding`)"
+                    hideCancel
+                >
+                    <template #default="{ isOpenModal, changeModel }">
+                        <Button :style="'secondary'" :icon="faCheck" :loading="isLoadingMarkValid" :label="'Mark as Valid'" @click="() => changeModel()" />
+                    </template>
+                    <template #btn-yes="{ closeModal }">
+                        <Button
+                            :label="trans('Confirm')"
+                            @click="
+                                () => {
+                                    markAsValid()
+                                    closeModal()
+                                }
+                            "
+                            type="negative"
+                            :icon="faWarning" />
+                    </template>
+                </ModalConfirmation>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary

Adds support for manually marking a customer's tax number as valid when automatic VAT validation is unsuccessful or cannot be used.

### Changes

* Add a **Mark as Valid** action to the customer tax number field.
* Allow users to manually mark an existing tax number as valid.
* Record the manual validation user and validation details in the VAT validation audit history.
* Prevent `mark_tax_number_valid` from being used when the customer does not have an existing tax number.
* Update the tax number validation flow to support manual validation without relying on the third-party validation result.
* Remove the `invalid_checked_at` update from the standard European VAT validation flow.

### Notes

The manual validation action is only available for customers with an existing tax number. The action updates the tax number status to `VALID` and marks it as manually validated.
