### PR TITLE
checkout.com: Swish phone on SEK sessions + session builders never crash on missing address / rejected credentials (HELP-2952)

### DIFF
--- a/app/Actions/Accounting/Payment/RefundPaymentCheckoutCom.php
+++ b/app/Actions/Accounting/Payment/RefundPaymentCheckoutCom.php
@@ -34,7 +34,9 @@ class RefundPaymentCheckoutCom extends OrgAction
         list($publicKey, $secretKey) = $paymentAccountShop->getCredentials();
 
         $checkoutApi = $this->getCheckoutApi($publicKey, $secretKey);
-
+        if (!$checkoutApi) {
+            throw new \RuntimeException('checkout.com credentials rejected for payment account shop '.$paymentAccountShop->id);
+        }
 
         try {
             $refundRequest = new RefundRequest();

--- a/app/Actions/Accounting/PaymentAccountShop/UI/GetRetinaPaymentAccountShopCheckoutComData.php
+++ b/app/Actions/Accounting/PaymentAccountShop/UI/GetRetinaPaymentAccountShopCheckoutComData.php
@@ -18,7 +18,6 @@ use Checkout\Payments\Sessions\PaymentSessionsRequest;
 use Checkout\Payments\ThreeDsRequest;
 use Checkout\Customers\CustomerRequest;
 use Lorisleiva\Actions\Concerns\AsObject;
-use Sentry;
 
 class GetRetinaPaymentAccountShopCheckoutComData
 {
@@ -32,6 +31,9 @@ class GetRetinaPaymentAccountShopCheckoutComData
         list($publicKey, $secretKey) = $paymentAccountShop->getCredentials();
 
         $checkoutApi = $this->getCheckoutApi($publicKey, $secretKey);
+        if (!$checkoutApi) {
+            return ['error' => __('Online payments are temporarily unavailable')];
+        }
 
         $paymentSessionClient = $checkoutApi->getPaymentSessionsClient();
 
@@ -71,6 +73,12 @@ class GetRetinaPaymentAccountShopCheckoutComData
         if ($order->customer->email) {
             $paymentSessionRequest->customer->email = $order->customer->email;
         }
+        $paymentSessionRequest = $this->setCustomerPhone(
+            $paymentSessionRequest,
+            $order->currency->code,
+            $order->customer,
+            $order->billingAddress?->country?->phone_code
+        );
 
         $paymentSessionRequest->metadata = [
             'origin'       => 'aiku',
@@ -89,16 +97,7 @@ class GetRetinaPaymentAccountShopCheckoutComData
 
         $paymentSessionRequest = $this->setBillingInformation($paymentSessionRequest, $billingAddress);
 
-        try {
-            $paymentSession = $paymentSessionClient->createPaymentSessions($paymentSessionRequest);
-        } catch (\Exception $e) {
-            $paymentSession = [
-                'error' => $e->getMessage(),
-            ];
-            Sentry::captureException($e);
-        }
-
-        return $paymentSession;
+        return $this->createPaymentSession($paymentSessionClient, $paymentSessionRequest);
     }
 
 

--- a/app/Actions/Accounting/WithCheckoutCom.php
+++ b/app/Actions/Accounting/WithCheckoutCom.php
@@ -9,12 +9,15 @@
 namespace App\Actions\Accounting;
 
 use App\Models\Accounting\PaymentAccountShop;
+use App\Models\CRM\Customer;
 use App\Models\Helpers\Address;
 use Checkout\CheckoutApiException;
+use Checkout\Customers\CustomerRequest;
 use Checkout\CheckoutSdk;
 use Checkout\Environment;
 use Checkout\Payments\BillingInformation;
 use Checkout\Payments\PaymentsQueryFilter;
+use Checkout\Payments\Sessions\PaymentSessionsClient;
 use Checkout\Payments\Sessions\PaymentSessionsRequest;
 use Sentry;
 
@@ -23,6 +26,7 @@ trait WithCheckoutCom
     public const array CHECKOUT_COM_PENDING_STATUSES = ['Pending', 'Retry Scheduled'];
     public const array CHECKOUT_COM_FAILURE_STATUSES = ['Voided', 'Declined', 'Cancelled', 'Canceled', 'Expired'];
     public const array CHECKOUT_COM_CAPTURED_STATUSES = ['Captured', 'Paid'];
+    public const array CHECKOUT_COM_CUSTOMER_PHONE_CURRENCIES = ['SEK'];
 
     public function getCheckoutApi($publicKey, $secretKey): ?\Checkout\CheckoutApi
     {
@@ -41,8 +45,12 @@ trait WithCheckoutCom
     }
 
 
-    private function setBillingInformation(PaymentSessionsRequest $paymentSessionRequest, Address $billingAddress): PaymentSessionsRequest
+    private function setBillingInformation(PaymentSessionsRequest $paymentSessionRequest, ?Address $billingAddress): PaymentSessionsRequest
     {
+        if (!$billingAddress?->country) {
+            return $paymentSessionRequest;
+        }
+
         $address                = new \Checkout\Common\Address();
         $address->address_line1 = $billingAddress->address_line_1;
         $address->address_line2 = $billingAddress->address_line_2;
@@ -58,11 +66,109 @@ trait WithCheckoutCom
         return $paymentSessionRequest;
     }
 
+    public function getCustomerPhone(?string $phone, ?string $billingCountryPhoneCode): ?\Checkout\Common\Phone
+    {
+        $phone = trim((string) $phone);
+        preg_match('/\d+/', (string) $billingCountryPhoneCode, $phoneCodeDigits);
+        $billingPhoneCode = $phoneCodeDigits[0] ?? '';
+        if ($phone === '' || $billingPhoneCode === '') {
+            return null;
+        }
+
+        $digits = preg_replace('/\D/', '', str_replace('(0)', '', $phone));
+
+        $carriesCountryCode = str_starts_with($phone, '+')
+            || str_starts_with($digits, '00')
+            || (!str_starts_with($digits, '0') && str_starts_with($digits, $billingPhoneCode) && strlen($digits) >= 10);
+
+        $international = $carriesCountryCode ? ltrim($digits, '0') : $billingPhoneCode.ltrim($digits, '0');
+
+        if (!str_starts_with($international, $billingPhoneCode)) {
+            if (strlen($international) < 8 || strlen($international) > 24) {
+                return null;
+            }
+            $checkoutPhone         = new \Checkout\Common\Phone();
+            $checkoutPhone->number = '+'.$international;
+
+            return $checkoutPhone;
+        }
+
+        $number = ltrim(substr($international, strlen($billingPhoneCode)), '0');
+        if (strlen($number) < 6 || strlen($number) > 25) {
+            return null;
+        }
+
+        $checkoutPhone               = new \Checkout\Common\Phone();
+        $checkoutPhone->country_code = '+'.$billingPhoneCode;
+        $checkoutPhone->number       = $number;
+
+        return $checkoutPhone;
+    }
+
+    private function setCustomerPhone(PaymentSessionsRequest $paymentSessionRequest, string $currencyCode, Customer $customer, ?string $billingCountryPhoneCode): PaymentSessionsRequest
+    {
+        if (!in_array($currencyCode, self::CHECKOUT_COM_CUSTOMER_PHONE_CURRENCIES)) {
+            return $paymentSessionRequest;
+        }
+
+        $customerPhone = $this->getCustomerPhone($customer->phone, $billingCountryPhoneCode);
+        if (!$customerPhone) {
+            return $paymentSessionRequest;
+        }
+
+        if (!$paymentSessionRequest->customer) {
+            $paymentSessionRequest->customer       = new CustomerRequest();
+            $paymentSessionRequest->customer->name = $customer->name;
+            if ($customer->email) {
+                $paymentSessionRequest->customer->email = $customer->email;
+            }
+        }
+        $paymentSessionRequest->customer->phone = $customerPhone;
+
+        return $paymentSessionRequest;
+    }
+
+    private function createPaymentSession(PaymentSessionsClient $paymentSessionClient, PaymentSessionsRequest $paymentSessionRequest): array
+    {
+        try {
+            return $paymentSessionClient->createPaymentSessions($paymentSessionRequest);
+        } catch (\Exception $e) {
+            Sentry::captureException($e);
+            if (!$this->isCustomerPhoneRejected($e, $paymentSessionRequest)) {
+                return ['error' => $e->getMessage()];
+            }
+        }
+
+        $paymentSessionRequest->customer->phone = null;
+        try {
+            return $paymentSessionClient->createPaymentSessions($paymentSessionRequest);
+        } catch (\Exception $e) {
+            Sentry::captureException($e);
+
+            return ['error' => $e->getMessage()];
+        }
+    }
+
+    private function isCustomerPhoneRejected(\Exception $e, PaymentSessionsRequest $paymentSessionRequest): bool
+    {
+        if (empty($paymentSessionRequest->customer?->phone) || !$e instanceof CheckoutApiException) {
+            return false;
+        }
+
+        return isset($e->http_metadata) && $e->http_metadata->getStatusCode() == 422;
+    }
+
     public function getCheckOutPaymentsByReference(PaymentAccountShop $paymentAccountShop, string $reference): array
     {
         list($publicKey, $secretKey) = $paymentAccountShop->getCredentials();
 
         $checkoutApi = $this->getCheckoutApi($publicKey, $secretKey);
+        if (!$checkoutApi) {
+            return [
+                'error'            => true,
+                'http_status_code' => null,
+            ];
+        }
 
         try {
             $queryFilter            = new PaymentsQueryFilter();
@@ -90,6 +196,13 @@ trait WithCheckoutCom
 
 
         $checkoutApi = $this->getCheckoutApi($publicKey, $secretKey);
+        if (!$checkoutApi) {
+            return [
+                'error'            => true,
+                'message'          => 'checkout.com credentials rejected',
+                'http_status_code' => null,
+            ];
+        }
 
         try {
             return $checkoutApi->getPaymentsClient()->getPaymentDetails($paymentID);

--- a/app/Actions/Retina/Accounting/MitSavedCard/UI/CreateMitSavedCard.php
+++ b/app/Actions/Retina/Accounting/MitSavedCard/UI/CreateMitSavedCard.php
@@ -35,9 +35,21 @@ class CreateMitSavedCard extends RetinaAction
             ->where('type', PaymentAccountTypeEnum::CHECKOUT)
             ->where('state', PaymentAccountShopStateEnum::ACTIVE)->first();
 
-        list($publicKey, $secretKey) = $paymentAccountShop->getCredentials();
-        $checkoutApi = $this->getCheckoutApi($publicKey, $secretKey);
-
+        $checkoutApi = null;
+        if ($paymentAccountShop) {
+            list($publicKey, $secretKey) = $paymentAccountShop->getCredentials();
+            $checkoutApi = $this->getCheckoutApi($publicKey, $secretKey);
+        }
+        if (!$checkoutApi) {
+            return [
+                'label'       => __('Online payments'),
+                'key'         => 'credit_card',
+                'environment' => app()->environment('production') ? 'production' : 'sandbox',
+                'locale'      => 'en',
+                'icon'        => 'fal fa-credit-card-front',
+                'data'        => ['error' => __('Online payments are temporarily unavailable')],
+            ];
+        }
 
         $mitSavedCard = StoreMitSavedCard::run(
             $this->customer,

--- a/app/Actions/Retina/UI/TopUp/ShowRetinaTopUpCheckout.php
+++ b/app/Actions/Retina/UI/TopUp/ShowRetinaTopUpCheckout.php
@@ -22,7 +22,6 @@ use Illuminate\Support\Facades\Redirect;
 use Inertia\Inertia;
 use Inertia\Response;
 use Lorisleiva\Actions\ActionRequest;
-use Sentry;
 
 class ShowRetinaTopUpCheckout extends RetinaAction
 {
@@ -36,6 +35,12 @@ class ShowRetinaTopUpCheckout extends RetinaAction
         list($publicKey, $secretKey) = $paymentAccountShop->getCredentials();
 
         $checkoutApi = $this->getCheckoutApi($publicKey, $secretKey);
+        if (!$checkoutApi) {
+            return [
+                'error'                         => __('Online payments are temporarily unavailable'),
+                'top_up_payment_api_point_ulid' => $topUpPaymentApiPoint->ulid,
+            ];
+        }
 
         $paymentSessionClient = $checkoutApi->getPaymentSessionsClient();
 
@@ -79,14 +84,14 @@ class ShowRetinaTopUpCheckout extends RetinaAction
             $this->customer->address
         );
 
-        try {
-            $paymentSession = $paymentSessionClient->createPaymentSessions($paymentSessionRequest);
-        } catch (\Exception $e) {
-            $paymentSession = [
-                'error' => $e->getMessage(),
-            ];
-            Sentry::captureException($e);
-        }
+        $paymentSessionRequest = $this->setCustomerPhone(
+            $paymentSessionRequest,
+            $this->shop->currency->code,
+            $this->customer,
+            $this->customer->address?->country?->phone_code
+        );
+
+        $paymentSession = $this->createPaymentSession($paymentSessionClient, $paymentSessionRequest);
 
         return [
             'label'                         => __('Online payments'),

--- a/resources/js/Components/Retina/Ecom/CheckoutPaymentCard.vue
+++ b/resources/js/Components/Retina/Ecom/CheckoutPaymentCard.vue
@@ -217,13 +217,6 @@ const onClickCopy = (textToCopy: string) => {
                 {{ trans("Retrying payment... Attempt :retryCount of :max_entries", { retryCount: retryCount, max_entries: MAX_RETRIES }) }}
             </div>
         </Transition>
-        
-        <!-- Section: payment session id -->
-        <div v-if="props.data?.data?.id" class="italic opacity-50 text-[10px] mt-5">
-           <span @click="useCopyText(props.data.data.id)" class="cursor-pointer">
-                {{ props.data.data.id }}
-            </span>
-        </div>
     </div>
 </template>
 

--- a/tests/Feature/AccountingTest.php
+++ b/tests/Feature/AccountingTest.php
@@ -2956,6 +2956,179 @@ describe('payment method from checkout.com source', function () {
     });
 });
 
+describe('checkout.com payment session customer phone', function () {
+    $checkoutCom = fn () => new class () {
+        use \App\Actions\Accounting\WithCheckoutCom;
+
+        public function phoneFor(\Checkout\Payments\Sessions\PaymentSessionsRequest $request, string $currency, \App\Models\CRM\Customer $customer, ?string $code): \Checkout\Payments\Sessions\PaymentSessionsRequest
+        {
+            return $this->setCustomerPhone($request, $currency, $customer, $code);
+        }
+
+        public function session(\Checkout\Payments\Sessions\PaymentSessionsClient $client, \Checkout\Payments\Sessions\PaymentSessionsRequest $request): array
+        {
+            return $this->createPaymentSession($client, $request);
+        }
+
+        public function billing(\Checkout\Payments\Sessions\PaymentSessionsRequest $request, ?\App\Models\Helpers\Address $address): \Checkout\Payments\Sessions\PaymentSessionsRequest
+        {
+            return $this->setBillingInformation($request, $address);
+        }
+    };
+
+    test('a missing billing address or rejected credentials degrade instead of crashing', function () use ($checkoutCom) {
+        $request = $checkoutCom()->billing(new \Checkout\Payments\Sessions\PaymentSessionsRequest(), null);
+        expect($request->billing)->toBeNull();
+
+        $addressWithoutCountry = new \App\Models\Helpers\Address();
+        $request               = $checkoutCom()->billing(new \Checkout\Payments\Sessions\PaymentSessionsRequest(), $addressWithoutCountry);
+        expect($request->billing)->toBeNull();
+
+        expect($checkoutCom()->getCheckoutApi('', ''))->toBeNull()
+            ->and($checkoutCom()->getCheckoutApi('not-a-key', 'nope'))->toBeNull();
+    });
+
+    $sessionRequestWithPhone = function (): \Checkout\Payments\Sessions\PaymentSessionsRequest {
+        $request                          = new \Checkout\Payments\Sessions\PaymentSessionsRequest();
+        $request->customer                = new \Checkout\Customers\CustomerRequest();
+        $request->customer->phone         = new \Checkout\Common\Phone();
+        $request->customer->phone->number = '737589344';
+
+        return $request;
+    };
+
+    $phoneRejected                = new \Checkout\CheckoutApiException('422');
+    $phoneRejected->http_metadata = new \Checkout\HttpMetadata('Unprocessable Entity', 422, [], '1.1');
+    $phoneRejected->error_details = ['error_codes' => ['customer_phone_number_invalid']];
+
+    test('stored phones are split using the billing country dialing code', function () use ($checkoutCom) {
+        $parse = fn (?string $phone, ?string $code = '46') => $checkoutCom()->getCustomerPhone($phone, $code);
+
+        $compact = $parse('+46737589344');
+        expect($compact->country_code)->toBe('+46')->and($compact->number)->toBe('737589344');
+
+        $spaced = $parse('+46 73 758 93 44');
+        expect($spaced->country_code)->toBe('+46')->and($spaced->number)->toBe('737589344');
+
+        $national = $parse('0737589344');
+        expect($national->country_code)->toBe('+46')->and($national->number)->toBe('737589344');
+
+        $doubleZero = $parse('0046737589344');
+        expect($doubleZero->country_code)->toBe('+46')->and($doubleZero->number)->toBe('737589344');
+
+        $alreadyPrefixed = $parse('46737589344');
+        expect($alreadyPrefixed->country_code)->toBe('+46')->and($alreadyPrefixed->number)->toBe('737589344');
+
+        $polishPrefixed = $parse('48123456789', '48');
+        expect($polishPrefixed->country_code)->toBe('+48')->and($polishPrefixed->number)->toBe('123456789');
+
+        $lundLandlineWithoutTrunkZero = $parse('46123456');
+        expect($lundLandlineWithoutTrunkZero->country_code)->toBe('+46')->and($lundLandlineWithoutTrunkZero->number)->toBe('46123456');
+
+        $trunkZeroAfterCode = $parse('+46 073 758 93 44');
+        expect($trunkZeroAfterCode->country_code)->toBe('+46')->and($trunkZeroAfterCode->number)->toBe('737589344');
+
+        $trunkZero = $parse('+44 (0)1142 729 165', '44');
+        expect($trunkZero->country_code)->toBe('+44')->and($trunkZero->number)->toBe('1142729165');
+
+        $foreign = $parse('+358400915168');
+        expect($foreign->country_code)->toBeNull()->and($foreign->number)->toBe('+358400915168');
+
+        $compoundDialingCode = $parse('7371234567', '+1-809 and 1-829');
+        expect($compoundDialingCode->country_code)->toBe('+1')->and($compoundDialingCode->number)->toBe('7371234567');
+
+        $shortestAccepted = $parse('+46123456');
+        expect($shortestAccepted->number)->toBe('123456');
+
+        expect($parse('+46'))->toBeNull()
+            ->and($parse('+421000'))->toBeNull()
+            ->and($parse('+4612345'))->toBeNull()
+            ->and($parse('+46'.str_repeat('7', 26)))->toBeNull()
+            ->and($parse('+358'.str_repeat('7', 22)))->toBeNull()
+            ->and($parse('+3581234'))->toBeNull()
+            ->and($parse(''))->toBeNull()
+            ->and($parse(null))->toBeNull()
+            ->and($parse('+46737589344', ''))->toBeNull()
+            ->and($parse('+46737589344', ' '))->toBeNull()
+            ->and($parse('+46737589344', null))->toBeNull();
+    });
+
+    test('phone only travels on SEK sessions until BLIK is verified for PLN, other shops keep their payload', function () use ($checkoutCom) {
+        $customer        = new \App\Models\CRM\Customer();
+        $customer->name  = 'Test Swish';
+        $customer->email = 'swish@example.com';
+        $customer->phone = '+46737589344';
+
+        $orderFlow                 = new \Checkout\Payments\Sessions\PaymentSessionsRequest();
+        $orderFlow->customer       = new \Checkout\Customers\CustomerRequest();
+        $orderFlow->customer->name = 'Already there';
+        $orderFlow                 = $checkoutCom()->phoneFor($orderFlow, 'SEK', $customer, '46');
+        expect($orderFlow->customer->name)->toBe('Already there')
+            ->and($orderFlow->customer->phone->country_code)->toBe('+46')
+            ->and($orderFlow->customer->phone->number)->toBe('737589344');
+
+        $topUp = $checkoutCom()->phoneFor(new \Checkout\Payments\Sessions\PaymentSessionsRequest(), 'SEK', $customer, '46');
+        expect($topUp->customer)->toBeInstanceOf(\Checkout\Customers\CustomerRequest::class)
+            ->and($topUp->customer->name)->toBe('Test Swish')
+            ->and($topUp->customer->email)->toBe('swish@example.com')
+            ->and($topUp->customer->phone->number)->toBe('737589344');
+
+        $unparseable        = new \App\Models\CRM\Customer();
+        $unparseable->name  = 'No phone';
+        $unparseable->phone = '+46';
+        expect($checkoutCom()->phoneFor(new \Checkout\Payments\Sessions\PaymentSessionsRequest(), 'SEK', $unparseable, '46')->customer)->toBeNull();
+
+        $polish        = new \App\Models\CRM\Customer();
+        $polish->phone = '+48123456789';
+        expect($checkoutCom()->phoneFor(new \Checkout\Payments\Sessions\PaymentSessionsRequest(), 'PLN', $polish, '48')->customer)->toBeNull();
+
+        $euro           = new \Checkout\Payments\Sessions\PaymentSessionsRequest();
+        $euro->customer = new \Checkout\Customers\CustomerRequest();
+        $euro           = $checkoutCom()->phoneFor($euro, 'EUR', $customer, '46');
+        expect($euro->customer->phone)->toBeNull();
+
+        $sterling        = new \App\Models\CRM\Customer();
+        $sterling->phone = '+44 7984 903265';
+        expect($checkoutCom()->phoneFor(new \Checkout\Payments\Sessions\PaymentSessionsRequest(), 'GBP', $sterling, '44')->customer)->toBeNull();
+    });
+
+    test('a phone rejected by checkout.com is dropped and the session created again once', function () use ($checkoutCom, $sessionRequestWithPhone, $phoneRejected) {
+        $request = $sessionRequestWithPhone();
+        $client  = \Mockery::mock(\Checkout\Payments\Sessions\PaymentSessionsClient::class);
+        $client->shouldReceive('createPaymentSessions')->once()->andThrow($phoneRejected);
+        $client->shouldReceive('createPaymentSessions')->once()->andReturn(['id' => 'ps_retry']);
+
+        expect($checkoutCom()->session($client, $request))->toBe(['id' => 'ps_retry'])
+            ->and($request->customer->phone)->toBeNull();
+    });
+
+    test('other failures are never retried and keep the error shape', function () use ($checkoutCom, $sessionRequestWithPhone, $phoneRejected) {
+        $serverError                = new \Checkout\CheckoutApiException('500');
+        $serverError->http_metadata = new \Checkout\HttpMetadata('Internal Server Error', 500, [], '1.1');
+
+        $request = $sessionRequestWithPhone();
+        $client  = \Mockery::mock(\Checkout\Payments\Sessions\PaymentSessionsClient::class);
+        $client->shouldReceive('createPaymentSessions')->once()->andThrow($serverError);
+        expect($checkoutCom()->session($client, $request))->toBe(['error' => '500'])
+            ->and($request->customer->phone->number)->toBe('737589344');
+
+        $timeout = \Mockery::mock(\Checkout\Payments\Sessions\PaymentSessionsClient::class);
+        $timeout->shouldReceive('createPaymentSessions')->once()->andThrow(new \Exception('timeout'));
+        expect($checkoutCom()->session($timeout, $sessionRequestWithPhone()))->toBe(['error' => 'timeout']);
+
+        $noPhone           = new \Checkout\Payments\Sessions\PaymentSessionsRequest();
+        $noPhone->customer = new \Checkout\Customers\CustomerRequest();
+        $rejectedWithoutPhone = \Mockery::mock(\Checkout\Payments\Sessions\PaymentSessionsClient::class);
+        $rejectedWithoutPhone->shouldReceive('createPaymentSessions')->once()->andThrow($phoneRejected);
+        expect($checkoutCom()->session($rejectedWithoutPhone, $noPhone))->toBe(['error' => '422']);
+
+        $noCustomer = new \Checkout\Payments\Sessions\PaymentSessionsRequest();
+        $rejectedWithoutCustomer = \Mockery::mock(\Checkout\Payments\Sessions\PaymentSessionsClient::class);
+        $rejectedWithoutCustomer->shouldReceive('createPaymentSessions')->once()->andThrow($phoneRejected);
+        expect($checkoutCom()->session($rejectedWithoutCustomer, $noCustomer))->toBe(['error' => '422']);
+    });
+});
+
 describe('invoice pdf tax number display', function () {
     $renderInvoiceTemplate = function ($invoice) {
         return view('invoices.templates.pdf.invoice', [


### PR DESCRIPTION
## What

checkout.com enabled **Swish** (SEK) and **BLIK** (PLN) for us ([HELP-2952](https://inikoo.atlassian.net/browse/HELP-2952)). BLIK needed nothing from us. Swish's Flow component refuses to submit unless the payment session carries a customer phone, so:

- `WithCheckoutCom::getCustomerPhone()` turns our free-text `customers.phone` into checkout.com's `{country_code, number}` using the billing country's `countries.phone_code` (handles `+46…`, `+46 0…`, `0…`, `0046…`, `(0)`, compound `phone_code` values, checkout.com's length limits).
- `setCustomerPhone()` attaches it **only when the session currency is in `CHECKOUT_COM_CUSTOMER_PHONE_CURRENCIES = ['SEK']`** — i.e. the `se` shop only. Every other shop's checkout.com payload is byte-for-byte unchanged.
- `createPaymentSession()` wraps the SDK call: every failure goes to Sentry and returns the existing `['error' => …]` shape; if checkout.com answers **422** while a phone was attached, it drops the phone and retries once, so a bad phone can never block a card payment. Timeouts / 5xx are never retried.
- Hardening found in review: `setBillingInformation()` now skips billing when an order/customer has no address instead of a TypeError 500; every `getCheckoutApi()` caller guards a `null` (rejected credentials) instead of calling a method on null; MIT saved-card also guards a shop with no active checkout account.
- `Payment::methodLabel` knows `blik` / `swish`; the `ps_…` session id debug line under the payment widget is gone.

## Tested

- Sandbox, SE shop: Swish renders, submits, redirects to the Swish page; payment created at checkout.com (`source.type = swish`).
- Sandbox, plsk shop: BLIK renders and captures with **no** code change on that path; order recorded paid with `method = blik`.
- Pest: `checkout.com payment session customer phone` (parser cases, currency gate, retry via mocked SDK client, null address, rejected keys) + `method labels` — 6 tests, 69 assertions.

## QA — please test manually in local

**Normal credit-card payments only, in BOTH retina ecom and retina dropshipping** — normal orders and top-ups. There is no need to test Swish or BLIK. What matters is that the everyday flows behave exactly as before:

1. Checkout of a normal order with a **credit card** on a non-SE shop (e.g. UK / EU), once as an ecom customer and once as a dropshipping customer — pay, land on the order page, order paid.
2. A declined card, then a successful retry on the same order.
3. **Top-up** with a credit card.
4. Save a card (MIT saved card) from the retina dashboard.
5. If you can: a customer **without a saved address** opening checkout / top-up should see the payment form (or a clean error), not a 500.

## After QA

If the card flows above pass, **merge and deploy** — nothing else is needed. No migrations, no config/env changes, no new dependency, no cache to clear. Every non-SE shop behaves exactly as before; the only new behaviour (phone on SEK sessions, one retry on a 422) is unit-tested and sandbox-verified. Swish/BLIK appearing in production depends on checkout.com having enabled them on our production account — if they have not yet, the methods simply do not show and nothing else changes.

Not fixed here, pre-existing (separate ticket): the top-up page reads the wrong key when a session fails and renders a blank widget; raw exception text can reach the customer notification.

[HELP-2952]: https://inikoo.atlassian.net/browse/HELP-2952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ