### PR TITLE
feat: Enhance discount offer handling for product quantity and amount…

### DIFF
--- a/app/Actions/Discounts/Offer/UpdateProductCategoryOffersData.php
+++ b/app/Actions/Discounts/Offer/UpdateProductCategoryOffersData.php
@@ -137,6 +137,19 @@ class UpdateProductCategoryOffersData
                 'category'   => $categoryLink,
                 'percentage' => $percentage
             ]);
+        } elseif ($offer->type == 'Product Quantity Ordered') {
+            $triggerLabels[] = __(':n or more', ['n' => $offer->trigger_data['item_quantity']]);
+
+            $productsTriggerLabel = __('Order :n+ of this product to get :percentage off', [
+                'n'          => (int)$offer->trigger_data['item_quantity'],
+                'percentage' => $percentage
+            ]);
+        } elseif ($offer->type == 'Product Amount Ordered') {
+            $triggerLabels[] = __('Order this product');
+
+            $productsTriggerLabel = __('Order this product to get :percentage off', [
+                'percentage' => $percentage
+            ]);
         } elseif ($offer->type == 'Category Ordered') {
             $triggerLabels[] = __('Order any product in this range');
 

--- a/app/Models/Discounts/Offer.php
+++ b/app/Models/Discounts/Offer.php
@@ -212,7 +212,19 @@ class Offer extends Model implements Auditable
 
     public function hydratesCatalogueOffersData(): bool
     {
-        return $this->trigger_type == 'ProductCategory' || $this->targetCollectionIds() !== [];
+        return $this->trigger_type == 'ProductCategory' || $this->isProductPercentageOffDiscount() || $this->targetCollectionIds() !== [];
+    }
+
+    public function isProductPercentageOffDiscount(): bool
+    {
+        if ($this->trigger_type != 'Product') {
+            return false;
+        }
+
+        return $this->offerAllowances()
+            ->where('status', true)
+            ->whereNotNull('data->percentage_off')
+            ->exists();
     }
 
     public function transactions(): BelongsToMany

--- a/resources/js/Components/Utils/Label/DiscountByType.vue
+++ b/resources/js/Components/Utils/Label/DiscountByType.vue
@@ -32,6 +32,7 @@ const componentsMap = {
     'Subdepartment Ordered': defineAsyncComponent(() => import("@/Components/Utils/Label/DiscountTemplate/CategoryOrdered/OfferPivotCategoryOrdered.vue")),
     'Category Quantity Ordered': defineAsyncComponent(() => import("@/Components/Utils/Label/DiscountTemplate/CategoryOrdered/OfferPivotCategoryOrdered.vue")),
     'Product Quantity Ordered': defineAsyncComponent(() => import("@/Components/Utils/Label/DiscountTemplate/CategoryOrdered/OfferPivotCategoryOrdered.vue")),
+    'Product Amount Ordered': defineAsyncComponent(() => import("@/Components/Utils/Label/DiscountTemplate/CategoryOrdered/OfferPivotCategoryOrdered.vue")),
     'Shop Ordered': defineAsyncComponent(() => import("@/Components/Utils/Label/DiscountTemplate/CategoryOrdered/OfferPivotCategoryOrdered.vue"))
 
 } as const

--- a/resources/js/Iris/Components/BlocksUtils/Prices4.vue
+++ b/resources/js/Iris/Components/BlocksUtils/Prices4.vue
@@ -445,6 +445,10 @@ const onHideStepsPopover = () => {
                         :offers_data="product?.product_offers_data" template="max_discount_3" :use_duration="false" />
                     <DiscountByType v-if="bestOffer?.type == 'Subdepartment Ordered'"
                         :offers_data="product?.product_offers_data" template="max_discount_3" :use_duration="false" />
+                    <DiscountByType v-if="bestOffer?.type == 'Product Quantity Ordered'"
+                        :offers_data="product?.product_offers_data" template="max_discount_3" :use_duration="false" />
+                    <DiscountByType v-if="bestOffer?.type == 'Product Amount Ordered'"
+                        :offers_data="product?.product_offers_data" template="max_discount_3" :use_duration="false" />
                     <div v-else class="w-full"></div>
                 </div>
 


### PR DESCRIPTION
**Root Cause**
Iris reads the best offer from products.offers_data, which is hydrated by UpdateProductCategoryOffersData. That hydration only ran for offers with trigger_type == 'ProductCategory' or offers targeting a collection. Offers created via StoreProductDiscount use trigger_type == 'Product', so they were never written into offers_data — best_percentage_off only ever compared category/department offers, never the product-level one.

Order/basket/checkout calculation was unaffected, since CalculateOrderDiscounts queries the offers table directly and already handled Product Quantity Ordered / Product Amount Ordered.

**Changes**
Offer::hydratesCatalogueOffersData() now also returns true for product-trigger offers that have a percentage-off allowance (isProductPercentageOffDiscount()), so they get included in products.offers_data like category offers already are.
Step-discount offers (steps data, no flat percentage_off) are intentionally excluded to avoid duplicating what StepDiscountOffer already renders.
UpdateProductCategoryOffersData::getBasicOfferData() adds trigger/label branches for Product Quantity Ordered and Product Amount Ordered, matching the existing pattern for other offer types.